### PR TITLE
Add LLC domicile comparison CLI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # ekai
-Risk Management 
+
+This repository now includes a lightweight command-line application that helps compare
+limited liability company (LLC) domicile considerations across Mauritius, Seychelles,
+Rwanda, Uganda, and Kenya.
+
+## LLC domicile comparison app
+
+The application summarises headline tax rates, indicative formation and compliance
+costs, and qualitative strengths and watchpoints for each jurisdiction. You can use it
+to generate tables, narrative country profiles, or export the raw dataset as JSON.
+
+### Getting started
+
+Create (and activate) a Python 3.11+ virtual environment, then install the project in
+editable mode:
+
+```bash
+pip install -e .[dev]
+```
+
+Alternatively, you can simply run the module with the Python interpreter available on
+your system — the app has no third-party dependencies.
+
+### Usage
+
+Show the summary table (this is also the default behaviour):
+
+```bash
+python -m llc_domicile_app.cli --list
+```
+
+Display a detailed profile for a jurisdiction:
+
+```bash
+python -m llc_domicile_app.cli --detail Mauritius
+```
+
+Compare two countries side by side across numeric metrics:
+
+```bash
+python -m llc_domicile_app.cli --compare Mauritius Kenya
+```
+
+Export the knowledge base for use in other tools:
+
+```bash
+python -m llc_domicile_app.cli --json
+```
+
+### Running tests
+
+```bash
+pytest
+```

--- a/llc_domicile_app/__init__.py
+++ b/llc_domicile_app/__init__.py
@@ -1,0 +1,11 @@
+"""Tools for comparing LLC domicile options across selected African jurisdictions."""
+
+from .data import COUNTRY_DATA, METRIC_DESCRIPTIONS
+from .comparator import CountryProfile, LLCDomicileComparator
+
+__all__ = [
+    "COUNTRY_DATA",
+    "METRIC_DESCRIPTIONS",
+    "CountryProfile",
+    "LLCDomicileComparator",
+]

--- a/llc_domicile_app/cli.py
+++ b/llc_domicile_app/cli.py
@@ -1,0 +1,95 @@
+"""Command-line interface for comparing LLC domicile options."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Iterable
+
+from .comparator import LLCDomicileComparator, render_table
+from .data import METRIC_DESCRIPTIONS
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare LLC domicile considerations across selected African jurisdictions."
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Display a summary table of all countries.",
+    )
+    parser.add_argument(
+        "--detail",
+        metavar="COUNTRY",
+        help="Show a detailed narrative profile for the specified country.",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("LEFT", "RIGHT"),
+        help="Compare two countries across all numeric metrics.",
+    )
+    parser.add_argument(
+        "--metric",
+        choices=list(METRIC_DESCRIPTIONS),
+        help="Optional metric to sort the summary table by (used with --list).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the raw dataset in JSON format for downstream tooling.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> str:
+    args = parse_args(argv)
+    comparator = LLCDomicileComparator()
+
+    if args.json:
+        data = comparator.to_dicts()
+        return json.dumps(data, indent=2)
+
+    outputs: list[str] = []
+
+    if args.list or not (args.detail or args.compare):
+        outputs.append(comparator.format_summary_table(metric=args.metric))
+
+    if args.detail:
+        if outputs:
+            outputs.append("")
+        outputs.append(comparator.format_country_detail(args.detail))
+
+    if args.compare:
+        left, right = args.compare
+        comparison = comparator.compare(left, right)
+        if outputs:
+            outputs.append("")
+        outputs.append(_format_comparison(left, right, comparison))
+
+    return "\n".join(outputs)
+
+
+def _format_comparison(left: str, right: str, comparison: list[dict]) -> str:
+    headers = ["Metric", left.title(), right.title()]
+    rows = [
+        [item["description"], _format_value(item["left"]), _format_value(item["right"])]
+        for item in comparison
+    ]
+    return render_table(headers, rows)
+
+
+def _format_value(value: object) -> str:
+    if isinstance(value, int):
+        return f"{value:,}"
+    if isinstance(value, float):
+        if value.is_integer():
+            return f"{value:.0f}"
+        return f"{value:.2f}".rstrip("0").rstrip(".")
+    return str(value)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    print(main())

--- a/llc_domicile_app/comparator.py
+++ b/llc_domicile_app/comparator.py
@@ -1,0 +1,167 @@
+"""Comparison utilities for LLC domicile analysis."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Iterable, List, Sequence
+
+from .data import COUNTRY_DATA, METRIC_DESCRIPTIONS, CountryProfile
+
+
+class CountryNotFoundError(ValueError):
+    """Raised when a requested country is unavailable in the dataset."""
+
+
+class LLCDomicileComparator:
+    """High-level helper that exposes comparison primitives for the CLI."""
+
+    def __init__(self, dataset: Sequence[CountryProfile] | None = None) -> None:
+        self._dataset: List[CountryProfile] = list(dataset or COUNTRY_DATA)
+        self._index = {profile.name.lower(): profile for profile in self._dataset}
+
+    # ------------------------------------------------------------------
+    # Dataset helpers
+    # ------------------------------------------------------------------
+    def list_countries(self) -> List[CountryProfile]:
+        """Return all domicile profiles."""
+
+        return list(self._dataset)
+
+    def get_country(self, name: str) -> CountryProfile:
+        """Fetch a country profile by name (case-insensitive)."""
+
+        key = name.strip().lower()
+        try:
+            return self._index[key]
+        except KeyError as exc:  # pragma: no cover - exercised in tests
+            raise CountryNotFoundError(f"Country '{name}' is not in the dataset") from exc
+
+    # ------------------------------------------------------------------
+    # Comparison logic
+    # ------------------------------------------------------------------
+    def rank_by(self, metric: str, reverse: bool | None = None) -> List[CountryProfile]:
+        """Return countries sorted by the specified metric."""
+
+        if metric not in METRIC_DESCRIPTIONS:
+            raise KeyError(
+                f"Unknown metric '{metric}'. Choose from: {', '.join(METRIC_DESCRIPTIONS)}"
+            )
+
+        if reverse is None:
+            reverse = metric in {"treaty_network_score", "compliance_rigour"}
+
+        return sorted(self._dataset, key=lambda profile: getattr(profile, metric), reverse=reverse)
+
+    def compare(self, left: str, right: str, metrics: Iterable[str] | None = None) -> List[dict]:
+        """Build a point-by-point comparison between two countries."""
+
+        left_profile = self.get_country(left)
+        right_profile = self.get_country(right)
+
+        selected_metrics = list(metrics) if metrics else list(METRIC_DESCRIPTIONS)
+
+        comparison = []
+        for metric in selected_metrics:
+            if metric not in METRIC_DESCRIPTIONS:
+                raise KeyError(
+                    f"Unknown metric '{metric}'. Choose from: {', '.join(METRIC_DESCRIPTIONS)}"
+                )
+
+            comparison.append(
+                {
+                    "metric": metric,
+                    "description": METRIC_DESCRIPTIONS[metric],
+                    "left": getattr(left_profile, metric),
+                    "right": getattr(right_profile, metric),
+                }
+            )
+
+        return comparison
+
+    # ------------------------------------------------------------------
+    # Formatting helpers for the CLI
+    # ------------------------------------------------------------------
+    def format_summary_table(self, metric: str | None = None) -> str:
+        """Return a formatted table with a quick overview."""
+
+        profiles = self.rank_by(metric or "treaty_network_score") if metric else self.list_countries()
+        headers = [
+            "Country",
+            "Corp Tax %",
+            "VAT %",
+            "Formation (weeks)",
+            "Formation Cost (USD)",
+            "Annual Compliance (USD)",
+            "Treaty Score",
+            "Compliance Rigour",
+        ]
+
+        rows = [
+            [
+                profile.name,
+                f"{profile.corporate_tax_rate:g}",
+                f"{profile.vat_rate:g}",
+                f"{profile.formation_time_weeks:g}",
+                f"{profile.formation_cost_usd:,}",
+                f"{profile.annual_compliance_cost_usd:,}",
+                profile.treaty_network_score,
+                profile.compliance_rigour,
+            ]
+            for profile in profiles
+        ]
+
+        return render_table(headers, rows)
+
+    def format_country_detail(self, name: str) -> str:
+        """Present a detailed description of a country profile."""
+
+        profile = self.get_country(name)
+        lines = [
+            f"{profile.name}",
+            "=" * len(profile.name),
+            f"Corporate tax rate: {profile.corporate_tax_rate:g}%",
+            f"VAT: {profile.vat_rate:g}%",
+            f"Typical formation time: {profile.formation_time_weeks:g} weeks",
+            f"Estimated formation cost: USD {profile.formation_cost_usd:,}",
+            f"Estimated annual compliance cost: USD {profile.annual_compliance_cost_usd:,}",
+            f"Treaty network score: {profile.treaty_network_score}/10",
+            f"Compliance rigour: {profile.compliance_rigour}/10",
+            "Strengths:",
+        ]
+        lines.extend(f"  • {item}" for item in profile.strengths)
+        lines.append("Watchpoints:")
+        lines.extend(f"  • {item}" for item in profile.watchpoints)
+        lines.append("")
+        lines.append(profile.notes)
+        return "\n".join(lines)
+
+    def to_dicts(self) -> List[dict]:
+        """Return the dataset as serialisable dictionaries."""
+
+        return [asdict(profile) for profile in self._dataset]
+
+
+def render_table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    """Render a plain-text table with padded columns."""
+
+    col_widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            col_widths[idx] = max(col_widths[idx], len(str(cell)))
+
+    def _format_row(row: Sequence[str]) -> str:
+        return " | ".join(str(cell).ljust(col_widths[idx]) for idx, cell in enumerate(row))
+
+    divider = "-+-".join("-" * width for width in col_widths)
+    output = [_format_row(headers), divider]
+    for row in rows:
+        output.append(_format_row(row))
+
+    return "\n".join(output)
+
+
+__all__ = [
+    "CountryNotFoundError",
+    "LLCDomicileComparator",
+    "render_table",
+]

--- a/llc_domicile_app/data.py
+++ b/llc_domicile_app/data.py
@@ -1,0 +1,159 @@
+"""Domain knowledge for the LLC domicile comparison app."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class CountryProfile:
+    """Structured snapshot of an LLC domicile option."""
+
+    name: str
+    corporate_tax_rate: float
+    vat_rate: float
+    formation_time_weeks: float
+    formation_cost_usd: int
+    annual_compliance_cost_usd: int
+    treaty_network_score: int
+    compliance_rigour: int
+    strengths: List[str]
+    watchpoints: List[str]
+    notes: str
+
+
+COUNTRY_DATA: List[CountryProfile] = [
+    CountryProfile(
+        name="Mauritius",
+        corporate_tax_rate=15.0,
+        vat_rate=15.0,
+        formation_time_weeks=2.0,
+        formation_cost_usd=850,
+        annual_compliance_cost_usd=1200,
+        treaty_network_score=8,
+        compliance_rigour=7,
+        strengths=[
+            "Extensive double tax treaty network across Africa, Europe, and Asia",
+            "Partial exemption regime can reduce effective corporate tax to 3% for qualifying export services",
+            "Sophisticated banking, legal, and fiduciary support infrastructure",
+        ],
+        watchpoints=[
+            "Economic substance rules require local directors and expenditure for most global business activities",
+            "Global tax reforms (Pillar Two, minimum tax) may narrow preferential rates",
+            "Regulator expects audited financial statements for most entities",
+        ],
+        notes=(
+            "Mauritius remains a popular holding jurisdiction thanks to treaty access and a stable legal system. "
+            "However, substance and reporting expectations are steadily increasing, which raises recurring costs."
+        ),
+    ),
+    CountryProfile(
+        name="Seychelles",
+        corporate_tax_rate=1.5,
+        vat_rate=15.0,
+        formation_time_weeks=1.0,
+        formation_cost_usd=650,
+        annual_compliance_cost_usd=950,
+        treaty_network_score=3,
+        compliance_rigour=5,
+        strengths=[
+            "Fast incorporation with straightforward documentation requirements",
+            "Low corporate income tax rate for companies conducting business primarily outside Seychelles",
+            "IBC regime supports flexible share classes and no minimum capital",
+        ],
+        watchpoints=[
+            "Smaller double tax treaty network compared to Mauritius",
+            "Heightened scrutiny in some financial centres due to past transparency concerns",
+            "Economic substance rules apply for entities engaged in relevant activities (e.g., headquarters, distribution)",
+        ],
+        notes=(
+            "Seychelles suits smaller trading or holding structures needing cost efficiency and quick turnaround. "
+            "Firms targeting institutional investors often prefer jurisdictions with deeper treaty access."
+        ),
+    ),
+    CountryProfile(
+        name="Rwanda",
+        corporate_tax_rate=30.0,
+        vat_rate=18.0,
+        formation_time_weeks=1.5,
+        formation_cost_usd=420,
+        annual_compliance_cost_usd=600,
+        treaty_network_score=4,
+        compliance_rigour=8,
+        strengths=[
+            "Modern company registry with largely digital workflows",
+            "Incentive regimes (including preferential rates in special economic zones) for strategic investments",
+            "Stable governance and strong push for ease of doing business reforms",
+        ],
+        watchpoints=[
+            "Standard corporate tax rate of 30% absent incentives",
+            "Requires annual audited financial statements for companies exceeding size thresholds",
+            "Local director or representative requirements for certain regulated sectors",
+        ],
+        notes=(
+            "Rwanda works well for operators with on-the-ground activity in East Africa who want predictable compliance. "
+            "The jurisdiction emphasises transparency and timely filings; incentives should be confirmed in writing."
+        ),
+    ),
+    CountryProfile(
+        name="Uganda",
+        corporate_tax_rate=30.0,
+        vat_rate=18.0,
+        formation_time_weeks=2.5,
+        formation_cost_usd=380,
+        annual_compliance_cost_usd=550,
+        treaty_network_score=5,
+        compliance_rigour=6,
+        strengths=[
+            "Access to East African Community and COMESA markets",
+            "Straightforward shareholding rules with 100% foreign ownership allowed in most sectors",
+            "Reasonable formation costs and availability of professional company secretarial support",
+        ],
+        watchpoints=[
+            "Revenue Authority actively scrutinises transfer pricing and withholding tax compliance",
+            "Tax filings are monthly for VAT and PAYE, increasing administrative touchpoints",
+            "Delays may occur when reserving company names or obtaining investment licences",
+        ],
+        notes=(
+            "Uganda is practical for businesses targeting the local consumer market or natural resources. "
+            "Expect hands-on engagement with the tax authority and be prepared for frequent filings."
+        ),
+    ),
+    CountryProfile(
+        name="Kenya",
+        corporate_tax_rate=30.0,
+        vat_rate=16.0,
+        formation_time_weeks=2.0,
+        formation_cost_usd=520,
+        annual_compliance_cost_usd=700,
+        treaty_network_score=7,
+        compliance_rigour=7,
+        strengths=[
+            "Regional financial hub with deep professional services ecosystem",
+            "Access to an expanding double tax treaty network, including with key African peers",
+            "Robust fintech and technology ecosystem supporting venture and holding structures",
+        ],
+        watchpoints=[
+            "Frequent tax law amendments require continuous monitoring",
+            "Minimum tax and digital service tax proposals can affect certain business models",
+            "Regulators expect annual audited accounts for most private companies",
+        ],
+        notes=(
+            "Kenya suits operating companies and regional headquarters needing connectivity and capital access. "
+            "The jurisdiction balances opportunity with relatively intensive compliance oversight."
+        ),
+    ),
+]
+
+
+METRIC_DESCRIPTIONS = {
+    "corporate_tax_rate": "Headline corporate income tax rate (before incentives)",
+    "vat_rate": "Standard value-added tax rate",
+    "formation_time_weeks": "Typical time to incorporate an LLC-equivalent (weeks)",
+    "formation_cost_usd": "Estimated professional and government fees to form (USD)",
+    "annual_compliance_cost_usd": "Indicative annual compliance/secretarial budget (USD)",
+    "treaty_network_score": "Relative depth of the double tax treaty network (1-10)",
+    "compliance_rigour": "Regulatory and reporting intensity (1-10, higher is stricter)",
+}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llc-domicile-app"
+version = "0.1.0"
+description = "CLI to compare LLC domicile considerations in East African jurisdictions"
+readme = "README.md"
+authors = [{ name = "ekai" }]
+requires-python = ">=3.11"
+license = { text = "MIT" }
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["llc_domicile_app*"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -1,0 +1,30 @@
+"""Unit tests for the LLC domicile comparator."""
+
+from llc_domicile_app import COUNTRY_DATA, LLCDomicileComparator, METRIC_DESCRIPTIONS
+
+
+def test_get_country_is_case_insensitive():
+    comparator = LLCDomicileComparator()
+    kenya = comparator.get_country("kEnYa")
+    assert kenya.name == "Kenya"
+
+
+def test_rank_by_metric_descending_for_scores():
+    comparator = LLCDomicileComparator()
+    ranked = comparator.rank_by("treaty_network_score")
+    scores = [profile.treaty_network_score for profile in ranked]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_compare_returns_all_metrics_by_default():
+    comparator = LLCDomicileComparator()
+    comparison = comparator.compare("Mauritius", "Kenya")
+    metric_names = [item["metric"] for item in comparison]
+    assert metric_names == list(METRIC_DESCRIPTIONS)
+
+
+def test_to_dicts_matches_dataset_length():
+    comparator = LLCDomicileComparator()
+    data = comparator.to_dicts()
+    assert len(data) == len(COUNTRY_DATA)
+    assert {entry["name"] for entry in data} == {profile.name for profile in COUNTRY_DATA}


### PR DESCRIPTION
## Summary
- add a structured dataset describing LLC domicile considerations for Mauritius, Seychelles, Rwanda, Uganda, and Kenya
- implement a comparator utility and CLI to list, detail, compare, and export domicile information
- document usage, add packaging metadata, and introduce unit tests for the comparison helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6909e87938e4832e8a325d5ff0b5a13f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a zero-dependency CLI to list, detail, compare, and export LLC domicile data for five African jurisdictions.
> 
> - **CLI** (`llc_domicile_app/cli.py`):
>   - Add commands/flags: `--list`, `--detail COUNTRY`, `--compare LEFT RIGHT`, `--metric`, `--json`.
>   - Format outputs via plain-text tables and numeric formatting helpers.
> - **Core Comparator** (`llc_domicile_app/comparator.py`):
>   - Implement `LLCDomicileComparator` with `list_countries`, `get_country` (case-insensitive), `rank_by`, `compare`, `format_summary_table`, `format_country_detail`, `to_dicts`.
>   - Provide `CountryNotFoundError` and `render_table` utility.
> - **Data Model** (`llc_domicile_app/data.py`):
>   - Define `CountryProfile` dataclass and populate `COUNTRY_DATA` for Mauritius, Seychelles, Rwanda, Uganda, Kenya.
>   - Expose `METRIC_DESCRIPTIONS` for sortable/comparable metrics.
> - **Packaging** (`pyproject.toml`):
>   - Configure project metadata, Python >=3.11, and optional `dev` deps; expose package.
> - **Docs** (`README.md`):
>   - Add setup, usage examples, and test instructions.
> - **Tests** (`tests/test_comparator.py`):
>   - Verify case-insensitive lookup, ranking order, default comparison metrics, and dataset export consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cc53c155d8843896ca380aa8208610a620c6d44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->