### PR TITLE
Add two KRI blog posts: operational risk and manufacturing

### DIFF
--- a/blog/key-risk-indicators-examples-manufacturing-companies.md
+++ b/blog/key-risk-indicators-examples-manufacturing-companies.md
@@ -1,0 +1,332 @@
+---
+title: "Key Risk Indicators Examples for Manufacturing Companies (2026 Guide)"
+slug: key-risk-indicators-examples-manufacturing-companies
+target_keyword: key risk indicators examples for manufacturing
+meta_description: "30+ key risk indicators examples for manufacturing companies, mapped to OSHA, ISO 31000, ISO 45001, and ISO 14001. With formulas, thresholds, and owners."
+word_count_target: 2500-3000
+pattern: "Pattern A: KRI Examples for [Industry]"
+mirrors: "KRI Examples for Banks"
+priority: High
+---
+
+# Key Risk Indicators Examples for Manufacturing Companies (2026 Guide)
+
+A manufacturing company's risk profile does not look like a bank's. Where a bank loses money to credit defaults and trading errors, a manufacturer loses it to a press that goes down for 11 hours, a supplier that ships a contaminated lot, an OSHA recordable that triggers an inspection, or a single energy-price spike that wipes out a quarter's margin. The risks are physical, operational, and deeply tied to the shop floor.
+
+Key Risk Indicators (KRIs) translate those risks into numbers the plant manager, the COO, and the board can act on *before* the loss is booked. This guide collects 30+ key risk indicators examples specifically for manufacturing companies, organised by the seven domains that drive most manufacturing losses: safety, quality, supply chain, equipment, environmental, cyber-OT, and people. Each example includes a formula, a threshold range, and the owner.
+
+Use it as a working reference when you are building a manufacturing KRI library for the first time, or pruning one that has grown past usefulness.
+
+## What Counts as a KRI in a Manufacturing Context?
+
+A Key Risk Indicator is a quantifiable, forward-looking metric that signals a *change in risk exposure* before that risk becomes a loss event. In manufacturing this distinction matters because most plants already drown in operational data: OEE, takt time, scrap, throughput, units per hour. Those are KPIs — they tell you whether you achieved a production goal. KRIs tell you whether the *risk* of missing the goal, injuring someone, or breaching a permit is rising.
+
+A workable manufacturing KRI has five attributes:
+
+1. **Forward-looking** — moves before the loss event.
+2. **Quantifiable** — a number on a defined cadence (per shift, per day, per week, per month).
+3. **Tied to a specific risk on the register** — safety, quality, supply, equipment, environmental, cyber-OT, or people.
+4. **Threshold-bound** — green, amber, and red levels, signed off by the plant or function owner.
+5. **Owned** — a named individual is accountable for the metric and the response.
+
+A manufacturer with 80 metrics on a wall and no owners has data, not KRIs.
+
+## Why Manufacturing KRIs Matter More in 2026
+
+Three forces have raised the stakes for manufacturing risk monitoring:
+
+- **Regulatory tightening.** OSHA's revised electronic recordkeeping rule (29 CFR 1904.41) requires Form 300A, 300, and 301 submissions for many establishments, making safety KRIs visible in a public database. ISO 45001:2018 (occupational health and safety) and ISO 14001:2015 (environmental) both require *monitoring and measurement* — KRIs are the standard way of evidencing it.
+- **Supply-chain volatility.** The shocks of 2020–2024 — semiconductor allocation, Suez and Panama canal disruption, Red Sea routing, regional electricity rationing — have made supplier KRIs a board-level topic.
+- **Cyber-OT convergence.** Ransomware attacks on operational technology environments are no longer rare. CISA, NIST SP 800-82, and IEC 62443 all expect manufacturing firms to monitor OT specifically — separately from corporate IT.
+
+Mature manufacturers respond by treating KRIs as the daily telemetry of the risk register, not as an annual reporting exercise.
+
+## The Seven KRI Domains in Manufacturing
+
+Most manufacturing risk registers can be reduced to seven domains. Organising your KRI library this way keeps the dashboard coherent and maps cleanly to the standards:
+
+1. Safety and occupational health (OSHA, ISO 45001)
+2. Product quality and recall (ISO 9001, customer-specific schemes such as IATF 16949)
+3. Supply chain and supplier risk
+4. Equipment, maintenance, and reliability
+5. Environmental and energy (ISO 14001, ISO 50001)
+6. Cyber-OT and information security (NIST SP 800-82, IEC 62443)
+7. People, skills, and labour relations
+
+The 30+ examples below sit under those seven domains.
+
+## 1. Safety and Occupational Health KRIs
+
+Safety is the most universal KRI domain in manufacturing because the metrics are standardised by OSHA and ISO 45001 and the loss events (injuries, fatalities, citations) are unambiguous.
+
+**KRI 1.1 — Total Recordable Incident Rate (TRIR)**
+- Formula: (Recordable injuries × 200,000) ÷ total hours worked.
+- Threshold: Green ≤ 1.5, Amber 1.5–3.0, Red > 3.0 (calibrate to NAICS benchmark).
+- Owner: EHS Manager.
+
+**KRI 1.2 — Lost-Time Injury Frequency Rate (LTIFR)**
+- Formula: (Lost-time injuries × 1,000,000) ÷ total hours worked.
+- Threshold: Green ≤ 1.0, Amber 1.0–2.0, Red > 2.0.
+- Owner: EHS Manager.
+
+**KRI 1.3 — Near-Miss Reporting Ratio**
+- Formula: Near-misses reported ÷ recordable injuries (rolling 12 months).
+- Threshold: Green ≥ 10:1, Amber 5–10:1, Red < 5:1. *Lower is worse — it indicates under-reporting.*
+- Owner: Plant Safety Lead.
+
+**KRI 1.4 — Open Corrective Actions from Safety Audits**
+- Formula: Count of safety audit corrective actions past their committed close date.
+- Threshold: Green ≤ 3, Amber 4–10, Red > 10.
+- Owner: EHS Manager.
+
+**KRI 1.5 — Lockout/Tagout (LOTO) Compliance**
+- Formula: % of energy-isolation activities sampled in the period that were fully compliant with LOTO procedure.
+- Threshold: Green ≥ 98%, Amber 95–98%, Red < 95%.
+- Owner: Maintenance Manager.
+
+**KRI 1.6 — Permit-to-Work Exceptions**
+- Formula: Count of high-risk activities (hot work, confined space, working at height) executed without a valid permit per month.
+- Threshold: Green = 0; any breach is red.
+- Owner: Plant Manager.
+
+## 2. Product Quality and Recall KRIs
+
+Quality KRIs target the early signals of customer escapes, regulatory recalls, and warranty cost spikes. In automotive, aerospace, and food/pharma manufacturing these are typically the most heavily instrumented metrics on site.
+
+**KRI 2.1 — First-Pass Yield (FPY) Trend**
+- Formula: Units passing first inspection ÷ units started, per line, per shift.
+- Threshold: Set as 30-day rolling baseline ± 2σ; red is sustained breach over 3 shifts.
+- Owner: Quality Manager.
+
+**KRI 2.2 — Parts Per Million (PPM) Defects to Customer**
+- Formula: (Defective parts shipped ÷ total parts shipped) × 1,000,000, monthly.
+- Threshold: Green < customer-agreed target, Amber within 25% of target, Red over target.
+- Owner: Quality Manager.
+
+**KRI 2.3 — Customer Complaints / Returns Trend**
+- Formula: Customer complaints per 10,000 units shipped, rolling 3 months.
+- Threshold: 6-month baseline + 2σ as red.
+- Owner: Quality Manager.
+
+**KRI 2.4 — Open 8D / CAPA Past Due**
+- Formula: Count of corrective and preventive action records open beyond agreed close date.
+- Threshold: Green ≤ 5, Amber 6–15, Red > 15.
+- Owner: Quality Manager.
+
+**KRI 2.5 — Cost of Poor Quality (COPQ) as % of Revenue**
+- Formula: (Scrap + rework + warranty + customer-returns cost) ÷ revenue.
+- Threshold: Green ≤ 1.5%, Amber 1.5–3%, Red > 3%.
+- Owner: COO / Plant Controller.
+
+**KRI 2.6 — Calibration Compliance**
+- Formula: % of measurement and test equipment with calibration current at month-end.
+- Threshold: Green ≥ 98%, Amber 95–98%, Red < 95%.
+- Owner: Quality Manager.
+
+## 3. Supply Chain and Supplier Risk KRIs
+
+Supply chain is the domain where manufacturers' risk registers have grown the fastest since 2020. The KRIs here aim to detect supplier weakness, single-source exposure, and inbound-material risk before they show up as a line stoppage.
+
+**KRI 3.1 — Single-Source Critical Components**
+- Formula: Count of critical components with only one approved supplier and no qualified alternative.
+- Threshold: Green ≤ 5, Amber 6–15, Red > 15.
+- Owner: Procurement Director.
+
+**KRI 3.2 — Supplier On-Time-In-Full (OTIF)**
+- Formula: % of POs received on time and complete, per critical supplier, monthly.
+- Threshold: Green ≥ 95%, Amber 90–95%, Red < 90%.
+- Owner: Procurement Manager.
+
+**KRI 3.3 — Inbound Defect Rate (IDR)**
+- Formula: PPM defective on incoming inspection, per critical supplier.
+- Threshold: Set against contractual target; red on > 50% deviation.
+- Owner: Quality / Procurement.
+
+**KRI 3.4 — Supplier Financial Health Score**
+- Formula: External credit-risk score (e.g. D&B PAYDEX, Creditsafe) for each Tier-1 critical supplier.
+- Threshold: Green ≥ 70, Amber 50–70, Red < 50.
+- Owner: Procurement Director.
+
+**KRI 3.5 — Inventory Days of Cover for Critical Materials**
+- Formula: On-hand inventory ÷ average daily consumption, per critical SKU.
+- Threshold: Set against contingency policy (e.g. green ≥ 30 days, red < 14).
+- Owner: Supply Chain Manager.
+
+**KRI 3.6 — Geopolitical Concentration**
+- Formula: % of spend in regions flagged as high geopolitical / sanctions risk.
+- Threshold: Set against board-approved appetite.
+- Owner: Procurement Director.
+
+## 4. Equipment, Maintenance, and Reliability KRIs
+
+Equipment KRIs target the leading signals of unplanned downtime, capacity loss, and the safety incidents that often follow ageing or under-maintained assets.
+
+**KRI 4.1 — Mean Time Between Failures (MTBF)**
+- Formula: Total operating time ÷ number of failures, per critical asset.
+- Threshold: Asset-specific; tracked as trend with 3-month rolling baseline.
+- Owner: Maintenance Manager.
+
+**KRI 4.2 — Mean Time to Repair (MTTR)**
+- Formula: Total downtime ÷ number of failures, per critical asset.
+- Threshold: Set against capacity-loss tolerance.
+- Owner: Maintenance Manager.
+
+**KRI 4.3 — Planned Maintenance Compliance**
+- Formula: % of scheduled preventive-maintenance tasks completed on time.
+- Threshold: Green ≥ 95%, Amber 90–95%, Red < 90%.
+- Owner: Maintenance Planner.
+
+**KRI 4.4 — Unplanned Downtime as % of Available Time**
+- Formula: Unplanned downtime hours ÷ scheduled production hours.
+- Threshold: Green ≤ 3%, Amber 3–7%, Red > 7%.
+- Owner: Plant Manager.
+
+**KRI 4.5 — Backlog of Work Orders Aged > 30 Days**
+- Formula: Count of open maintenance work orders past 30 days.
+- Threshold: Tracked as trend; red on > 20% MoM increase.
+- Owner: Maintenance Manager.
+
+## 5. Environmental and Energy KRIs
+
+Environmental KRIs target compliance with ISO 14001, the firm's environmental permits, and increasingly its public climate commitments. Energy KRIs are increasingly tracked as risk indicators because energy-price volatility now moves the P&L of energy-intensive manufacturers (steel, aluminium, glass, chemicals) materially each quarter.
+
+**KRI 5.1 — Permit Limit Exceedances**
+- Formula: Count of recorded exceedances against air, water, or waste permit limits per quarter.
+- Threshold: Green = 0; any breach is red.
+- Owner: EHS Manager.
+
+**KRI 5.2 — Spill / Release Events**
+- Formula: Count of reportable environmental spill or release events per quarter.
+- Threshold: Green = 0; any breach is red.
+- Owner: EHS Manager.
+
+**KRI 5.3 — Energy Intensity Drift**
+- Formula: Energy consumed (MWh) per unit of output, monthly, vs. baseline.
+- Threshold: Green within ±2% of baseline, Amber 2–5%, Red > 5%.
+- Owner: Energy Manager / Plant Engineer.
+
+**KRI 5.4 — Scope 1 and 2 Emissions vs. Annual Target**
+- Formula: Cumulative tCO₂e ÷ annual target, year-to-date.
+- Threshold: Green within 100% of pro-rata target; Amber 100–110%; Red > 110%.
+- Owner: Sustainability Lead.
+
+**KRI 5.5 — Water Withdrawal in Stressed Basins**
+- Formula: Volume of water withdrawn at sites flagged as high or extremely high water-stress (e.g. WRI Aqueduct).
+- Threshold: Set against site-level reduction targets.
+- Owner: Sustainability Lead.
+
+## 6. Cyber-OT and Information Security KRIs
+
+Cyber-OT KRIs are deliberately separate from corporate IT KRIs because OT environments have different patching constraints, different network segmentation, and different blast radii. NIST SP 800-82 Rev 3 and IEC 62443 are the usual references.
+
+**KRI 6.1 — OT Network Segmentation Exceptions**
+- Formula: Count of approved exceptions allowing direct connectivity between IT and OT zones.
+- Threshold: Green ≤ 3, Amber 4–10, Red > 10.
+- Owner: OT Security Lead.
+
+**KRI 6.2 — OT Patching Compliance for Critical Systems**
+- Formula: % of OT assets patched within agreed maintenance window.
+- Threshold: Green ≥ 90%, Amber 80–90%, Red < 80% (lower than IT because of patching constraints).
+- Owner: OT Security Lead.
+
+**KRI 6.3 — Unauthorised Removable Media Events**
+- Formula: Count of unauthorised USB / removable media insertions detected on OT endpoints per month.
+- Threshold: Green ≤ 2, Amber 3–10, Red > 10.
+- Owner: OT Security Lead.
+
+**KRI 6.4 — Backup Restore Test Success for Plant Systems**
+- Formula: % of scheduled restore tests for HMI / SCADA / historian backups that succeeded.
+- Threshold: Green = 100%, Amber 95–99%, Red < 95%.
+- Owner: OT Security Lead.
+
+**KRI 6.5 — Time Since Last OT Tabletop Exercise**
+- Formula: Months since last OT-specific incident-response tabletop, per plant.
+- Threshold: Green ≤ 6, Amber 7–12, Red > 12.
+- Owner: CISO.
+
+## 7. People, Skills, and Labour Relations KRIs
+
+People KRIs in manufacturing are not soft — they correlate directly with safety incidents, scrap rates, and supplier escalations. A plant that has lost half its skilled trades will see all three move within a quarter.
+
+**KRI 7.1 — Skilled-Trades Vacancy Rate**
+- Formula: % of approved skilled-trades positions vacant.
+- Threshold: Green < 5%, Amber 5–15%, Red > 15%.
+- Owner: HR Director.
+
+**KRI 7.2 — Overtime as % of Regular Hours**
+- Formula: Overtime hours ÷ regular hours, per plant, monthly.
+- Threshold: Green < 8%, Amber 8–15%, Red > 15%.
+- Owner: HR / Operations.
+
+**KRI 7.3 — Voluntary Attrition in Critical Roles**
+- Formula: Rolling 12-month voluntary attrition for production supervisors, quality engineers, maintenance technicians, and EHS leads.
+- Threshold: Green ≤ 8%, Amber 8–15%, Red > 15%.
+- Owner: HR Director.
+
+**KRI 7.4 — Mandatory Training Currency**
+- Formula: % of employees with current safety, quality, and process training.
+- Threshold: Green ≥ 98%, Amber 95–98%, Red < 95%.
+- Owner: HR / EHS / Quality.
+
+**KRI 7.5 — Time to Backfill Critical Roles**
+- Formula: Average days from vacancy to start date for critical roles.
+- Threshold: Set against benchmark (e.g. green ≤ 60 days, red > 120).
+- Owner: HR Director.
+
+## How to Build a Manufacturing KRI Library That Actually Gets Used
+
+A common failure pattern at manufacturing sites is the "control-room wall" of metrics — every screen lit up, nothing acted on. Six rules keep a manufacturing KRI library alive:
+
+1. **Start from the risk register, not the SCADA.** For each top risk, ask "what would move first if this got worse?" Then go find or build the metric.
+2. **Cap the executive set.** A site leadership team can absorb 15–20 active KRIs at the weekly operations review. The rest belong in the wider library and only escalate on breach.
+3. **Pair every KRI with a Key Control Indicator.** "Permit-limit exceedances = 0" is reassuring only if the control sampling and calibration KRIs are also green.
+4. **Set thresholds to appetite, not to history.** A 95th-percentile threshold guarantees a quarterly red; that is statistics, not signal.
+5. **Automate from the source.** Pull from MES, CMMS, EHS systems, and the supplier portal — manual spreadsheets degrade in two cycles.
+6. **Review thresholds twice a year.** New products, new lines, new suppliers all change the risk profile; static thresholds become noise.
+
+## A Sample Plant KRI Dashboard
+
+A workable plant-level dashboard tends to follow the same shape:
+
+- **Top strip:** TRIR, LTIFR, PPM defects to customer, OTIF on critical inbound, unplanned downtime %.
+- **Heatmap:** seven KRI domains × three lines (or three plants), coloured by the worst KRI status in each cell.
+- **Trend panel:** the five KRIs that moved the most this period.
+- **Watch list:** any KRI amber for two consecutive periods.
+- **Closed loop:** prior-period reds with current status and owner.
+
+The dashboard is not a reporting artefact. It is the spine of a 30-minute conversation about which two or three things the site will do differently next month.
+
+## Common Pitfalls
+
+- **Mixing KPIs with KRIs.** OEE is a performance metric; *deviation* of OEE from baseline can be a risk metric. Don't put them on the same chart without distinguishing.
+- **Lagging indicators dressed up as KRIs.** Recordable injuries booked, customer recalls issued, and permit fines paid are outcome metrics. They belong in the dashboard but they are not early warnings.
+- **No owner.** If the KRI does not have a named accountable manager, the breach response will be theatre.
+- **Static libraries.** New product launches, new suppliers, and new lines all change the risk profile. The library must change with them.
+- **Reporting up only.** KRIs must drive shop-floor action too — the operator on a press should see the tier-1 board with the same logic the COO sees on the tier-4 dashboard.
+
+## A 90-Day Plan to Reset a Manufacturing KRI Programme
+
+If your KRI programme has drifted, a 90-day reset that has worked at multiple sites looks like this:
+
+- **Days 1–30:** map the top 20 risks on the manufacturing risk register to existing metrics. Identify the gaps. Kill any KRI that no one has reviewed in the last two cycles.
+- **Days 31–60:** redesign each plant's dashboard to a single page, with thresholds approved by the plant manager. Automate the three most painful manual feeds (typically EHS, supplier OTIF, calibration).
+- **Days 61–90:** run the new dashboard at the weekly ops review for two cycles, capturing every challenge and gap. Publish the revised library, the owners list, and the schedule for the next threshold review.
+
+Manufacturing risk is physical, visible, and unforgiving — but it is also among the most measurable categories of enterprise risk. A working library of key risk indicators for your manufacturing company, organised across safety, quality, supply, equipment, environmental, cyber-OT, and people, is what turns daily plant data into a sensing system the board can rely on.
+
+## Frequently Asked Questions
+
+**How many KRIs should a manufacturing site have?**
+A working executive set is typically 15–20 active KRIs at site level, with a wider library of 60–100 monitored metrics that escalate only on breach. At enterprise level, a roll-up of 25–35 across plants is normal.
+
+**Do small manufacturers need a formal KRI library?**
+Yes — at a smaller scale. A small plant can run a credible programme on 10–12 KRIs covering TRIR, near-miss ratio, FPY, OTIF, unplanned downtime, calibration compliance, and permit exceedances.
+
+**How do KRIs relate to ISO 31000 and ISO 45001?**
+ISO 31000 (risk management) treats KRIs as part of the *monitoring and review* element of the risk-management process. ISO 45001 (occupational H&S) and ISO 14001 (environmental) both require *monitoring and measurement* — KRIs are the standard mechanism for evidencing it.
+
+**What is the difference between an operational KPI and a manufacturing KRI?**
+A KPI measures whether you achieved a goal (units shipped, OEE, takt time). A KRI measures whether the *risk* of missing a goal, breaching a permit, or harming someone is rising. Many KRIs are derived from KPI data — e.g. "deviation of OEE from baseline by more than 2σ for three shifts" — but the lens is risk, not performance.
+
+**How often should manufacturing KRIs be reviewed?**
+The data should refresh on the cadence of the underlying process — per shift for production, daily for supplier OTIF, monthly for environmental and people, quarterly for permits. Threshold reviews should happen at least twice a year, and after any material change in product, line, or supplier.

--- a/blog/operational-risk-key-risk-indicators-examples.md
+++ b/blog/operational-risk-key-risk-indicators-examples.md
@@ -1,0 +1,311 @@
+---
+title: "Operational Risk Key Risk Indicators Examples: A Practical 2026 Guide"
+slug: operational-risk-key-risk-indicators-examples
+target_keyword: operational risk key risk indicators
+meta_description: "30+ operational risk key risk indicators examples with formulas, thresholds, and Basel-aligned categories. A practical playbook for risk teams."
+word_count_target: 3000
+pattern: "Pattern B: [Risk Type] KRI Examples"
+mirrors: "Fraud KRI Examples"
+priority: High
+---
+
+# Operational Risk Key Risk Indicators Examples: A Practical 2026 Guide
+
+Operational risk is the quiet bleed in most organizations. It does not arrive as a single catastrophic event the way a credit default or a market crash does. It seeps in through a missed control, a wire sent to the wrong account, a junior analyst leaving without a handover, a vendor outage at 2 a.m., a process that "always worked" until it didn't. By the time finance sees the number, the damage is already booked.
+
+Key Risk Indicators (KRIs) are the early-warning instruments that turn this slow bleed into something measurable, something the board can see *before* it shows up in the loss event database. Done well, operational risk KRIs change the conversation from "what happened?" to "what is about to happen, and what do we do about it?"
+
+This guide walks through 30+ operational risk key risk indicators examples grouped the way the Basel Committee categorises operational risk events. For each one, you will see the metric, a sample formula, a typical threshold, and what to do when it breaches. Use it as a working reference rather than a one-time read.
+
+## What Is an Operational Risk Key Risk Indicator?
+
+A KRI is a quantifiable metric that signals a *change in the level of risk exposure* before that risk crystallises into an actual loss. It is not the same as a Key Performance Indicator (KPI), which measures whether you achieved a goal, and it is not the same as a Key Control Indicator (KCI), which measures whether a specific control is operating.
+
+A useful operational risk KRI has five attributes:
+
+1. **Forward-looking** — it moves before the loss event, not after.
+2. **Quantifiable** — it produces a number on a defined cadence (daily, weekly, monthly).
+3. **Linked to a specific risk** — you can name the risk it is monitoring.
+4. **Threshold-bound** — green, amber, and red levels are defined and signed off.
+5. **Owned** — a named individual is accountable for the metric and the response.
+
+If a candidate metric fails any of these tests, it is data — not a KRI.
+
+## Why Operational Risk KRIs Matter Now
+
+Three pressures make operational risk KRIs more important in 2026 than they were five years ago:
+
+- **The Basel III finalisation reforms** replaced the old Advanced Measurement Approach with the Standardised Measurement Approach (SMA), which uses the Business Indicator and the Internal Loss Multiplier. Firms with high historical losses pay more capital, which means *forward-looking indicators* now have a direct line to capital savings.
+- **Operational resilience regulation** in the UK (PRA SS1/21), the EU (DORA, in force since January 2025), and the US (Interagency Guidance on Third-Party Risk) requires firms to set "impact tolerances" and prove they can stay within them. KRIs are the daily telemetry that proves it.
+- **AI-driven process change** has compressed the time between a control weakness emerging and a loss occurring. Manual monthly reviews are too slow; KRIs need to be near real-time wherever the underlying process is.
+
+The firms that get this right treat KRIs as a *system*, not a list — instrumented, automated, and reviewed in the same cadence as the underlying process.
+
+## The Seven Basel Operational Risk Categories
+
+The Basel Committee defines seven Level 1 operational risk event types. Most mature operational risk frameworks organise their KRI library around these so the indicators map directly to loss data and capital models:
+
+1. Internal Fraud
+2. External Fraud
+3. Employment Practices and Workplace Safety
+4. Clients, Products, and Business Practices
+5. Damage to Physical Assets
+6. Business Disruption and System Failures
+7. Execution, Delivery, and Process Management
+
+The 30+ examples below are grouped under these categories, plus two cross-cutting categories that almost every firm now tracks separately: **Third-Party Risk** and **People Risk**.
+
+## 1. Internal Fraud KRIs
+
+Internal fraud is statistically rare but high-severity. The KRIs here aim to detect the *conditions* under which internal fraud becomes possible — concentration of access, override of controls, weakening of segregation of duties.
+
+**KRI 1.1 — Segregation of Duties (SoD) Conflicts Open**
+- Formula: Count of unresolved SoD conflicts in the IAM system at month-end.
+- Threshold: Green ≤ 5, Amber 6–15, Red > 15.
+- Response: Red triggers compensating-control review and a 30-day remediation plan to the ORC.
+
+**KRI 1.2 — Privileged Access Reviews Overdue**
+- Formula: (Privileged accounts with overdue quarterly review ÷ total privileged accounts) × 100.
+- Threshold: Green ≤ 2%, Amber 2–5%, Red > 5%.
+- Response: Red freezes new privileged grants until backlog is cleared.
+
+**KRI 1.3 — Manual Journal Entries Above Materiality, Posted by Preparer**
+- Formula: Count of manual journals > materiality threshold posted without a separate approver in the period.
+- Threshold: Green = 0, Amber 1–2, Red ≥ 3.
+- Response: Each red item is reviewed by Internal Audit within 10 working days.
+
+**KRI 1.4 — Vendor Master File Changes by Non-Authorised Users**
+- Formula: Count of bank-detail changes in the vendor master made by users outside the authorised list per month.
+- Threshold: Green = 0, Amber 1, Red ≥ 2.
+
+## 2. External Fraud KRIs
+
+External fraud is high-frequency and increasingly automated. The leading indicators are the volumes that *precede* loss events — attempted fraud, fraud-pattern hit rates, and authentication anomalies.
+
+**KRI 2.1 — Attempted Fraud Volume**
+- Formula: Number of transactions blocked by fraud rules per 10,000 transactions, per channel.
+- Threshold: Set as 30-day rolling baseline ± 2 standard deviations; red is > +3σ.
+- Response: Red triggers a same-day pattern review by the fraud team.
+
+**KRI 2.2 — Card-Not-Present Chargeback Ratio**
+- Formula: (Chargeback value ÷ CNP transaction value) × 100, monthly.
+- Threshold: Green < 0.5%, Amber 0.5–1.0%, Red > 1.0% (network monitoring threshold).
+
+**KRI 2.3 — Authentication Failure Spikes**
+- Formula: % increase in failed authentication attempts vs. trailing 7-day average.
+- Threshold: Green < 25%, Amber 25–50%, Red > 50%.
+
+**KRI 2.4 — Account Takeover Reports**
+- Formula: Customer-reported ATO incidents per 100,000 active accounts, monthly.
+- Threshold: Set against industry benchmark from APWG / national fraud body.
+
+## 3. Employment Practices and Workplace Safety KRIs
+
+This category is where the line between HR metrics and risk metrics gets blurred. The KRIs that matter for operational risk are the ones that signal *cultural* or *physical safety* breakdowns likely to produce a loss event.
+
+**KRI 3.1 — Whistleblower Reports per 1,000 Employees**
+- Formula: Count of whistleblower / speak-up reports in the quarter ÷ total headcount × 1,000.
+- Threshold: Below industry benchmark is itself a risk indicator (under-reporting). Use red = > 50% deviation in either direction.
+
+**KRI 3.2 — Lost-Time Injury Frequency Rate (LTIFR)**
+- Formula: (Lost-time injuries × 1,000,000) ÷ total hours worked.
+- Threshold: Green ≤ 1.0, Amber 1.0–2.0, Red > 2.0 (varies sharply by industry).
+
+**KRI 3.3 — Mandatory Training Completion**
+- Formula: % of employees with current AML, anti-bribery, code-of-conduct, and information-security training.
+- Threshold: Green ≥ 98%, Amber 95–98%, Red < 95%.
+
+**KRI 3.4 — Voluntary Attrition in High-Risk Roles**
+- Formula: Rolling 12-month voluntary attrition for roles flagged as high-risk (treasury dealers, model owners, compliance officers, key engineers).
+- Threshold: Green ≤ 10%, Amber 10–18%, Red > 18%.
+
+## 4. Clients, Products, and Business Practices KRIs
+
+This is the largest loss category in most banks. The KRIs target conduct, product suitability, and complaints — the leading indicators of mis-selling, regulatory action, and class-action exposure.
+
+**KRI 4.1 — Complaint Volume Trend**
+- Formula: Complaints per 10,000 customers, monthly, segmented by product.
+- Threshold: 3-month rolling average + 2σ as red.
+- Response: Red triggers root-cause analysis to product committee within 15 days.
+
+**KRI 4.2 — Complaints Upheld by Ombudsman / Regulator**
+- Formula: % of escalated complaints decided against the firm.
+- Threshold: Green < 25%, Amber 25–40%, Red > 40%.
+
+**KRI 4.3 — Suitability Assessment Exceptions**
+- Formula: % of new investment / lending sales where the suitability assessment was overridden or skipped.
+- Threshold: Green < 1%, Amber 1–3%, Red > 3%.
+
+**KRI 4.4 — Regulatory Findings Open**
+- Formula: Count of open regulatory findings past their committed remediation date.
+- Threshold: Green = 0, Amber 1–2, Red ≥ 3.
+
+**KRI 4.5 — Marketing Material Approvals Bypassed**
+- Formula: Count of customer-facing materials published without compliance sign-off in the period.
+- Threshold: Green = 0; any breach is red.
+
+## 5. Damage to Physical Assets KRIs
+
+For most firms, this is a low-frequency category dominated by climate and security events. The KRIs here are increasingly cross-listed with climate-risk and resilience indicators.
+
+**KRI 5.1 — Sites in High-Hazard Climate Zones**
+- Formula: % of revenue-generating sites located in zones flagged as high physical-climate risk under the firm's chosen scenario (e.g. NGFS Disorderly).
+- Threshold: Set against board-approved appetite.
+
+**KRI 5.2 — Property Insurance Cover Ratio**
+- Formula: Insured value ÷ replacement value of physical estate.
+- Threshold: Green ≥ 95%, Amber 90–95%, Red < 90%.
+
+**KRI 5.3 — Physical Security Incidents**
+- Formula: Count of physical security incidents (intrusion, theft, unauthorised access) per quarter.
+- Threshold: Tracked as trend; red on > 50% YoY increase.
+
+## 6. Business Disruption and System Failures KRIs
+
+This category is the home of operational resilience. The metrics here are the daily heartbeat of the firm, and most regulators now expect them to be reviewed at board level at least quarterly.
+
+**KRI 6.1 — Critical System Availability**
+- Formula: (Total uptime ÷ scheduled uptime) × 100, per critical service.
+- Threshold: Green ≥ 99.95%, Amber 99.9–99.95%, Red < 99.9% (calibrate to the firm's impact tolerance).
+
+**KRI 6.2 — P1/P2 Incidents per Month**
+- Formula: Count of priority-1 and priority-2 incidents affecting customer-facing services.
+- Threshold: 6-month rolling baseline + 2σ as red.
+
+**KRI 6.3 — Mean Time to Recover (MTTR)**
+- Formula: Sum of recovery time ÷ count of incidents, per service, monthly.
+- Threshold: Set to half the impact tolerance window.
+
+**KRI 6.4 — Backup Restore Test Success Rate**
+- Formula: % of scheduled backup restore tests that succeeded in the period.
+- Threshold: Green = 100%, Amber 95–99%, Red < 95%.
+
+**KRI 6.5 — Change Failure Rate**
+- Formula: (Failed or rolled-back production changes ÷ total production changes) × 100.
+- Threshold: Green < 5%, Amber 5–10%, Red > 10% (DORA Elite ≈ 0–5%).
+
+**KRI 6.6 — Cyber Patching Compliance**
+- Formula: % of critical / high CVEs patched within SLA.
+- Threshold: Green ≥ 98%, Amber 95–98%, Red < 95%.
+
+## 7. Execution, Delivery, and Process Management KRIs
+
+This is the category most associated with the day-to-day "noise" of operations — failed trades, wrong payments, reconciliation breaks. Volume is high, severity is usually low, but the *trend* tells you whether the underlying process is degrading.
+
+**KRI 7.1 — Reconciliation Breaks Aged > 30 Days**
+- Formula: Count and value of items unreconciled for more than 30 days at month-end.
+- Threshold: Green ≤ 5 items / < 0.01% of book, Amber and Red set proportionally.
+
+**KRI 7.2 — Failed Trade Rate**
+- Formula: (Failed settlement instructions ÷ total instructions) × 100, per asset class.
+- Threshold: Industry benchmark (e.g. CSDR cash-penalty triggers).
+
+**KRI 7.3 — Wire Payment Errors**
+- Formula: Count of wire payments requiring recall or amendment per 100,000 sent.
+- Threshold: Green < 5, Amber 5–10, Red > 10.
+
+**KRI 7.4 — Manual Workarounds in Live Use**
+- Formula: Count of documented manual workarounds bypassing automated controls.
+- Threshold: Tracked as a list; red on any new workaround in place > 60 days without a remediation plan.
+
+**KRI 7.5 — Process Capability Index (Cpk) for Critical Processes**
+- Formula: Cpk per critical process from operations data.
+- Threshold: Green ≥ 1.33, Amber 1.0–1.33, Red < 1.0.
+
+**KRI 7.6 — Aged Open Issues from Issue Log**
+- Formula: Count of open issues past target close date by 30+ days.
+- Threshold: Green ≤ 3, Amber 4–8, Red > 8.
+
+## 8. Third-Party and Outsourcing KRIs
+
+DORA, the PRA's operational resilience regime, and the US Interagency Guidance have all elevated third-party risk into a near-equal pillar with internal operational risk. These KRIs almost always sit on a separate dashboard now.
+
+**KRI 8.1 — Critical Third-Party Concentration**
+- Formula: % of critical services dependent on a single third party (or a single cloud region).
+- Threshold: Set against board appetite; red typically > 30% on a single provider.
+
+**KRI 8.2 — Third-Party SLA Breach Rate**
+- Formula: % of months in trailing 12 with at least one critical SLA breach, per critical vendor.
+- Threshold: Green ≤ 8%, Amber 9–25%, Red > 25%.
+
+**KRI 8.3 — Overdue Third-Party Risk Assessments**
+- Formula: Count of critical third parties with overdue annual risk assessment.
+- Threshold: Green = 0; any breach is red.
+
+**KRI 8.4 — Exit Plans Tested in Last 12 Months**
+- Formula: % of critical third parties with an exit / substitution plan tested in the trailing 12 months.
+- Threshold: Green ≥ 90%, Amber 70–90%, Red < 70%.
+
+## 9. People Risk (Cross-Cutting) KRIs
+
+Carving people risk out of category 3 is increasingly common because it covers more than safety — it covers continuity, capacity, and capability.
+
+**KRI 9.1 — Single Points of Knowledge**
+- Formula: Count of critical processes with only one individual capable of executing them end-to-end.
+- Threshold: Green ≤ 2, Amber 3–5, Red > 5.
+
+**KRI 9.2 — Span of Control Outliers**
+- Formula: Count of managers with > 12 direct reports in operational roles.
+- Threshold: Tracked as trend.
+
+**KRI 9.3 — Vacancy Rate in Control Functions**
+- Formula: % of approved positions vacant in risk, compliance, audit, and finance control teams.
+- Threshold: Green < 8%, Amber 8–15%, Red > 15%.
+
+## How to Build an Operational Risk KRI Library That People Actually Use
+
+A common failure pattern is the *KRI graveyard* — a 200-row spreadsheet that nobody reads because it is too long, too lagging, and too disconnected from decisions. Six rules keep a KRI library alive:
+
+1. **Start from the risk register, not the data.** For each top risk on the register, ask: "What would move first if this risk got worse?" Then look for the metric — not the other way around.
+2. **Cap the active set.** An executive risk committee can absorb roughly 20–30 KRIs in a quarter. Tier the rest as "monitored" — they exist, but they only escalate on breach.
+3. **Set thresholds the way you set risk appetite.** Green = within tolerance, Amber = approaching tolerance, Red = breach. Red must trigger a *named action*, not just a discussion.
+4. **Automate the data feed.** Anything that requires a human to populate a cell each month will degrade. Pull from source systems via the GRC platform or a data lake.
+5. **Pair every KRI with a Key Control Indicator.** A KRI tells you the risk is rising; the KCI tells you whether the control that should mitigate it is still working. Together they prevent the false comfort of "control in place, risk rising, no one notices."
+6. **Review thresholds twice a year.** Risk profiles drift; static thresholds become noise.
+
+## Operational Risk KRI Dashboard: A Sample Layout
+
+A workable executive dashboard tends to follow the same shape:
+
+- **Top strip:** the firm's three or four "impact tolerance" services with availability, MTTR, and incident count for the period.
+- **Heatmap:** Basel categories on one axis, business lines on the other, coloured by the worst KRI status in each cell.
+- **Trend panel:** the five KRIs that moved the most this period.
+- **Watch list:** any KRI that has been amber for two consecutive periods (early sign of a structural issue).
+- **Closed loop:** prior-period reds with current status and owner.
+
+The point of the dashboard is not to display data — it is to drive a 30-minute conversation about *which two or three things we are doing differently next quarter*.
+
+## Common Pitfalls
+
+- **Confusing volume with risk.** "We did 2 million payments" is not a KRI. "We had 14 wire errors per 100,000 payments, up from 7" is.
+- **Lagging indicators dressed up as KRIs.** Loss events booked, complaints upheld, and audit findings are *outcome* metrics. They belong in the dashboard but they are not early warnings.
+- **Thresholds set by data, not by appetite.** If you set red at the 95th percentile of historical data, you will *always* have one or two reds. That is not signal — it is arithmetic.
+- **No owner.** A KRI without a named accountable executive does not get acted on. The owner is the person who has to explain the breach.
+- **Static libraries.** New products, new geographies, and new vendors all change the risk profile. The KRI library has to change with them.
+
+## Putting It Into Practice This Quarter
+
+If your operational risk KRI programme needs a refresh, a 90-day plan that has worked for a lot of teams looks like this:
+
+- **Days 1–30:** map the top 20 risks on the operational risk register to existing metrics. Identify the gaps. Kill any KRI that no one has reviewed in the last two cycles.
+- **Days 31–60:** redesign the dashboard to a single page per business line, with thresholds explicitly approved by each business head. Automate the three most painful manual feeds.
+- **Days 61–90:** run the new dashboard at the operational risk committee for two cycles, capturing every challenge and gap. Publish the revised KRI library and the schedule for next year's threshold review.
+
+Operational risk will never be eliminated; it can only be sensed earlier and acted on faster. A working set of operational risk key risk indicators — Basel-aligned, automated, owned, and reviewed — is what turns the slow bleed into something the organisation can actually see.
+
+## Frequently Asked Questions
+
+**How many operational risk KRIs should a firm have?**
+A working executive set is typically 20–30 active KRIs, with a wider library of 80–150 monitored metrics that escalate only on breach. Beyond that the dashboard becomes noise.
+
+**What is the difference between a KRI and a KCI?**
+A Key Risk Indicator measures the level of risk exposure (e.g. failed trade rate). A Key Control Indicator measures whether a specific control is operating as designed (e.g. % of trades passing pre-trade compliance check). Mature frameworks use both.
+
+**How often should operational risk KRIs be reviewed?**
+The data should refresh on the cadence of the underlying process — daily for system availability, monthly for reconciliation breaks, quarterly for training completion. The *threshold review* should happen at least twice a year.
+
+**Are operational risk KRIs required by regulation?**
+Directly, no — but indirectly, yes. Basel III, DORA, PRA SS1/21, and the US Interagency Guidance all require firms to monitor operational risk and operational resilience on an ongoing basis. KRIs are the standard way of evidencing that monitoring.
+
+**Can small firms use this framework?**
+Yes. Smaller firms typically run with 10–15 active KRIs covering availability, payment errors, complaints, third-party SLA, and people risk. The structure is the same; only the scale changes.


### PR DESCRIPTION
## Summary
Drafts two High-priority blog posts from the content plan, each at the targeted word count and mirroring the "KRI Examples for Banks" structure used by the top-performing reference posts.

- **`blog/operational-risk-key-risk-indicators-examples.md`** — Pattern B pillar topic, 3,126 words, target keyword `operational risk key risk indicators`. Organised across the seven Basel operational-risk event categories plus third-party and people risk. Each KRI includes a formula, threshold range, and named owner; closes with a sample dashboard, pitfalls, a 90-day reset plan, and an FAQ.
- **`blog/key-risk-indicators-examples-manufacturing-companies.md`** — Pattern A lead, 3,074 words, target keyword `key risk indicators examples for manufacturing`. Organised across safety, quality, supply chain, equipment, environmental, cyber-OT, and people. References OSHA recordkeeping, ISO 31000 / 45001 / 14001, NIST SP 800-82, and IEC 62443 per the spreadsheet notes ("Strong vertical demand; OSHA/ISO links").

Each post follows the same shape: definition → why now → domain-grouped KRI examples (formula, threshold, owner) → dashboard layout → pitfalls → 90-day plan → FAQ.

## Test plan
- [ ] Editorial review of both posts (tone, accuracy of regulatory references, threshold ranges).
- [ ] SEO check: confirm target keyword density, meta description length, and slug.
- [ ] Verify front-matter fields render correctly in the publishing pipeline once one is selected.
- [ ] Cross-link to existing "KRI Examples for Banks", "Fraud KRI Examples", and "KRIs for HR" posts before publishing.
- [ ] Decide whether the FAQ blocks should be schema-marked-up for rich results.

https://claude.ai/code/session_01MXocpJuyKniJd8MB6BBpNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXocpJuyKniJd8MB6BBpNA)_