### PR TITLE
Add two KRI blog posts (manufacturing + operational risk)

### DIFF
--- a/blog/key-risk-indicators-examples-for-manufacturing-companies.md
+++ b/blog/key-risk-indicators-examples-for-manufacturing-companies.md
@@ -1,0 +1,244 @@
+---
+title: "Key Risk Indicators Examples for Manufacturing Companies"
+slug: key-risk-indicators-examples-for-manufacturing-companies
+target_keyword: key risk indicators examples for manufacturing
+meta_description: "A practical guide to key risk indicators (KRIs) for manufacturing companies, with 40+ examples across safety, supply chain, quality, ESG, and operations — aligned to OSHA, ISO 31000, and ISO 45001."
+category: Enterprise Risk Management
+tags: [manufacturing, KRI, operational risk, OSHA, ISO 31000, supply chain, safety]
+word_count: 2900
+---
+
+# Key Risk Indicators Examples for Manufacturing Companies
+
+Manufacturing leaders no longer compete on cost alone. They compete on resilience — the ability to keep production lines running despite raw-material shocks, cyber intrusions on the plant floor, regulatory inspections, climate disruption, and a tightening labor market. That resilience starts with one thing: **knowing which numbers tell you a problem is forming before it lands on the income statement.**
+
+That is what key risk indicators (KRIs) are for. Unlike key performance indicators (KPIs), which measure how well you executed yesterday, KRIs are forward-looking signals that quantify the *probability and severity* of a future loss. A KPI tells the plant manager that throughput hit 94% of plan last week. A KRI tells the same manager that unplanned downtime is trending 18% above the rolling 90-day baseline — which means next week's throughput is already at risk.
+
+This guide collects more than 40 practical key risk indicators examples for manufacturing companies, organized by risk domain, with target thresholds, data sources, and the regulatory or framework anchors (OSHA, ISO 31000, ISO 45001, ISO 14001, NIST CSF) that auditors expect to see referenced in your enterprise risk management (ERM) documentation.
+
+## What is a Key Risk Indicator in a Manufacturing Context?
+
+A key risk indicator is a measurable metric that provides early warning of increasing risk exposure to a specific objective. In manufacturing, those objectives typically cluster into six areas:
+
+1. **Worker safety and occupational health**
+2. **Operational continuity and asset reliability**
+3. **Supply chain and raw materials**
+4. **Product quality and recall exposure**
+5. **Environmental, social, and governance (ESG)**
+6. **Cyber-physical and IT/OT security**
+
+A well-designed manufacturing KRI has five attributes:
+
+- **Predictive** — it moves *before* the underlying loss event occurs.
+- **Quantifiable** — it produces a number, not a narrative.
+- **Comparable** — it can be benchmarked against an internal threshold or industry baseline.
+- **Owned** — a named role is accountable for monitoring and escalating.
+- **Actionable** — when the metric crosses a threshold, a specific response is triggered.
+
+If a metric does not meet all five tests, it is reporting, not risk indication.
+
+## How to Build a KRI Library for Your Plant Network
+
+Before listing examples, here is the workflow most ERM teams in manufacturing follow when they build (or rebuild) a KRI library:
+
+1. **Anchor to the risk register.** Every KRI must trace to a top risk in the enterprise or plant-level risk register. If a KRI does not map to a risk you have already identified, you are measuring noise.
+2. **Choose lead vs. lag deliberately.** Lagging indicators (e.g., recordable injury rate) are easy to measure but late. Leading indicators (e.g., near-miss reports per 1,000 hours) are harder to source but earlier. A balanced library carries both.
+3. **Set three-tier thresholds.** Most mature programs use green/amber/red bands. Green is "within tolerance," amber triggers escalation to the risk owner, red triggers escalation to the executive risk committee.
+4. **Assign frequency.** Safety KRIs are usually weekly. Supply chain KRIs are weekly or monthly. Strategic KRIs are quarterly. Match the cadence to how fast the underlying risk can change.
+5. **Automate the data feed.** KRIs that depend on someone manually pulling a spreadsheet rarely survive 12 months. Connect them to your MES, EAM, EHS, or GRC platform.
+6. **Review quarterly.** A KRI that has been green for eight straight quarters is either well-controlled or poorly designed. Pressure-test which.
+
+With that workflow in mind, the rest of this article is the library itself.
+
+## 1. Health, Safety, and Occupational Risk KRIs
+
+Safety remains the most visible risk category in manufacturing because regulators (OSHA in the US, HSE in the UK, equivalent bodies in the EU) publish injury statistics and enforce penalties on lagging performers. ISO 45001 also requires demonstrable monitoring of OH&S performance.
+
+| KRI | Target / Threshold | Data Source | Framework |
+|---|---|---|---|
+| **Total Recordable Incident Rate (TRIR)** | < 1.5 per 200,000 hours | OSHA 300 log | OSHA, ISO 45001 |
+| **Lost Time Injury Frequency Rate (LTIFR)** | < 0.5 per 200,000 hours | EHS system | ISO 45001 |
+| **Near-miss reports per 1,000 hours worked** | > 5 (higher is better — reflects reporting culture) | EHS reporting tool | ISO 45001 |
+| **Percentage of corrective actions closed on time** | > 95% | EHS / CAPA | ISO 45001 |
+| **Safety training completion rate** | > 98% | LMS | OSHA 1910 |
+| **Lockout/tagout audit pass rate** | > 99% | Plant audits | OSHA 1910.147 |
+| **Days since last serious incident** | Trending upward | Plant log | Internal |
+| **Contractor safety rating (avg)** | > 90/100 | Contractor mgmt | Internal |
+
+**Why the "near-miss" KRI matters.** A common pattern in mature manufacturers is that the *higher* the near-miss reporting rate, the *lower* the recordable injury rate. A sudden drop in near-miss reports is almost always an early warning that the reporting culture is breaking down, not that the plant became safer overnight.
+
+## 2. Operational and Asset Reliability KRIs
+
+These KRIs measure the risk that the plant cannot produce what the schedule says it should produce. They are the most direct link between risk management and EBITDA.
+
+| KRI | Target / Threshold | Data Source | Framework |
+|---|---|---|---|
+| **Unplanned downtime as % of available hours** | < 3% | MES | ISO 22301 |
+| **Mean Time Between Failures (MTBF) — critical assets** | Trending up | EAM / CMMS | ISO 55000 |
+| **Mean Time To Repair (MTTR)** | < 4 hours for tier-1 assets | EAM | ISO 55000 |
+| **Preventive maintenance completion rate** | > 90% | CMMS | ISO 55000 |
+| **Spare parts stock-out events on critical SKUs** | 0 per quarter | ERP | Internal |
+| **Overall Equipment Effectiveness (OEE) variance vs plan** | < 5 percentage points | MES | Internal |
+| **Single-source equipment dependencies** | Documented and < 10% of tier-1 assets | Asset register | ISO 22301 |
+| **Average asset age vs design life (%)** | < 75% for critical lines | Asset register | ISO 55000 |
+
+A practical tip: pair MTBF and MTTR. Together they tell you whether reliability is degrading because failures are more frequent, slower to repair, or both.
+
+## 3. Supply Chain and Raw Materials KRIs
+
+Post-2020, supply chain KRIs have moved from procurement back-office metrics to board-level risk indicators. ISO 28000 and the Sedex SMETA framework are the most commonly referenced anchors.
+
+| KRI | Target / Threshold | Data Source | Framework |
+|---|---|---|---|
+| **% of revenue dependent on single-source suppliers** | < 15% | Supplier master | ISO 28000 |
+| **On-time in-full (OTIF) delivery from tier-1 suppliers** | > 95% | ERP | Internal |
+| **Days of inventory cover for critical inputs** | > 30 days | ERP | Internal |
+| **Supplier financial health flags (Altman Z-score < 1.8)** | < 5% of tier-1 base | D&B / Bloomberg | Internal |
+| **Geopolitical concentration risk (% spend in single country)** | < 30% | Procurement | ISO 31000 |
+| **Logistics cost variance vs budget** | < 10% | Finance | Internal |
+| **Customs clearance rejection rate** | < 1% | Logistics | Internal |
+| **Tier-2 visibility (% of tier-1 disclosing tier-2)** | > 70% | Supplier portal | Sedex SMETA |
+
+The single-source KRI is often the most politically sensitive. Procurement teams resist disclosing it because it implies past sourcing decisions created risk. Resist that resistance — it is exactly what the audit committee needs to see.
+
+## 4. Quality and Product Recall KRIs
+
+Quality KRIs sit at the intersection of operational risk and reputational risk. A single recall in regulated sectors (medical devices, automotive, food) can erase a year of margin.
+
+| KRI | Target / Threshold | Data Source | Framework |
+|---|---|---|---|
+| **Customer complaints per million units shipped** | < 50 ppm | CRM / QMS | ISO 9001 |
+| **First-pass yield** | > 98% | MES | ISO 9001 |
+| **Cost of poor quality (COPQ) as % of revenue** | < 2% | Finance | ISO 9001 |
+| **Open Corrective and Preventive Actions (CAPAs) > 90 days** | < 5 | QMS | ISO 9001 |
+| **Supplier-caused defect rate** | < 1% of total defects | QMS | ISO 9001 |
+| **Recall events in trailing 24 months** | 0 | QMS | Sector reg |
+| **Audit findings classified as "major"** | 0 per cycle | Internal audit | ISO 19011 |
+| **Calibration overdue rate (test equipment)** | < 1% | QMS | ISO/IEC 17025 |
+
+## 5. Environmental, ESG, and Climate KRIs
+
+Whether your investors are asking about CSRD, SEC climate disclosures, or TCFD-aligned reporting, manufacturers need defensible environmental KRIs. ISO 14001 remains the operational anchor.
+
+| KRI | Target / Threshold | Data Source | Framework |
+|---|---|---|---|
+| **Scope 1+2 emissions intensity (tCO2e per unit output)** | Trending down vs baseline | Energy meters / EHS | TCFD, GHG Protocol |
+| **Water withdrawal in water-stressed locations (m³)** | < approved permit limits | EHS | CDP Water |
+| **Hazardous waste generated per unit output** | Trending down | EHS | RCRA / ISO 14001 |
+| **Reportable environmental incidents** | 0 per quarter | EHS | EPA / equivalent |
+| **% of plants with valid environmental permits** | 100% | Compliance | Local reg |
+| **Energy intensity (kWh per unit)** | Trending down | Utility data | ISO 50001 |
+| **% of tier-1 suppliers with disclosed Scope 1+2 data** | > 60% | Supplier portal | CDP Supply Chain |
+| **Stranded asset exposure (% of capex in high-risk geographies)** | Tracked | Strategy | TCFD |
+
+## 6. Cyber-Physical and OT Security KRIs
+
+The convergence of IT and operational technology (OT) — PLCs, SCADA, MES, IIoT sensors — has created a new risk class. Ransomware on a corporate network is painful; ransomware on a plant network stops production. NIST CSF and IEC 62443 are the most common anchors.
+
+| KRI | Target / Threshold | Data Source | Framework |
+|---|---|---|---|
+| **Mean Time To Detect (MTTD) for OT anomalies** | < 4 hours | SIEM / OT IDS | NIST CSF |
+| **% of OT assets in inventory and patched within SLA** | > 90% | CMDB | IEC 62443 |
+| **Number of legacy OT systems with no vendor support** | Documented and trending down | Asset register | NIST CSF |
+| **OT segmentation gaps identified per quarter** | < 5 | Network audits | IEC 62443 |
+| **Phishing simulation failure rate (plant staff)** | < 8% | Security awareness | NIST CSF |
+| **Privileged OT account reviews completed on time** | 100% | IAM | ISO 27001 |
+| **Backup restore test success rate (production systems)** | > 95% | Backup logs | ISO 22301 |
+| **Number of unauthorized USB / removable media detections** | Trending down | DLP / endpoint | NIST CSF |
+
+## 7. Workforce and Labor KRIs
+
+The labor market is now a manufacturing risk in its own right — particularly for skilled trades, machinists, and shift supervisors.
+
+| KRI | Target / Threshold | Data Source | Framework |
+|---|---|---|---|
+| **Voluntary turnover among production staff** | < 12% annual | HRIS | Internal |
+| **Open roles in critical trades > 60 days** | < 10% of headcount | HRIS / ATS | Internal |
+| **Overtime as % of total hours** | < 8% | Payroll | Internal |
+| **Training hours per FTE** | > 24 hours / year | LMS | ISO 45001 |
+| **Succession coverage for plant manager and shift leads** | > 1 ready-now successor | HR | Internal |
+| **Engagement survey score (production staff)** | > 75% favorable | Survey tool | Internal |
+
+## 8. Strategic and Reputational KRIs
+
+These KRIs are often run quarterly at the executive risk committee level rather than weekly at the plant.
+
+| KRI | Target / Threshold | Data Source |
+|---|---|---|
+| **Customer concentration (% revenue from top 5)** | < 40% | Finance |
+| **Regulatory enforcement actions in trailing 24 months** | 0 | Legal |
+| **Negative media mentions tied to plant operations** | Trending down | Media monitoring |
+| **NPS variance vs prior quarter** | > -5 points | CX |
+| **R&D pipeline coverage (% of revenue from products < 5 years old)** | > 25% | Strategy |
+
+## Putting the Library to Work: A Worked Example
+
+A KRI library is only valuable when it drives a decision. Here is how a mid-size automotive parts manufacturer might use this library in a single month.
+
+In week one, the **near-miss reporting rate** drops from 6.4 to 3.1 per 1,000 hours at one plant. That is a 51% drop. The plant manager investigates and finds that a long-tenured EHS lead retired and the replacement has not yet rebuilt the reporting cadence. **Action:** dedicated coaching and a reset of the daily safety huddle. The KRI is back in the green band within three weeks — and the plant avoids what data suggests would have been an injury within 60 days.
+
+In week two, the **single-source supplier KRI** crosses the 15% threshold because a competitor acquired one of the company's tier-1 suppliers, eliminating a backup. **Action:** procurement opens qualification of an alternate supplier in a different country, and the audit committee is briefed at the next quarterly risk review.
+
+In week three, the **OT MTTD** climbs from 3.5 hours to 6.8 hours after a SIEM rule was disabled to reduce alert fatigue. **Action:** the rule is re-enabled with tuned thresholds, and the security team adds OT MTTD to the monthly executive scorecard.
+
+None of those events would appear in a standard P&L review. All three would have shown up — late and expensively — as injuries, stockouts, or a ransomware-induced plant shutdown. That is the difference between KPI reporting and KRI-driven risk management.
+
+## Common Mistakes Manufacturers Make With KRIs
+
+Even well-resourced ERM teams stumble on the same handful of issues:
+
+- **Too many KRIs.** A library with 200 indicators gets ignored. Most mature manufacturers run 30–60 enterprise-level KRIs and a similar number at each plant.
+- **All lagging, no leading.** TRIR, recall counts, and downtime hours are necessary but tell you about yesterday. Pair every lagging indicator with at least one leading indicator.
+- **No owner.** A KRI without a named accountable person is a chart no one reads. Assign ownership at the plant manager, function head, or director level — not "the team."
+- **Static thresholds.** A 3% downtime threshold that was set in 2019 may be too loose for a modern lights-out line and too tight for an aging legacy plant. Recalibrate annually.
+- **Disconnected from controls.** A red KRI should map to a specific control that needs investment, redesign, or testing. If the response to a red KRI is a slide in next quarter's review, the link is broken.
+- **No board-level rollup.** Plant-level KRIs need a defensible aggregation method so the board sees enterprise risk, not a wall of numbers.
+
+## How These KRIs Map to Common Frameworks
+
+If your organization needs to demonstrate alignment to a recognized framework, here is the shortest defensible mapping:
+
+- **ISO 31000** — the principles and process anchor. Your KRI library is the *monitoring and review* element of the ISO 31000 process.
+- **COSO ERM 2017** — KRIs sit under the *Performance* component (specifically "Identifies and Analyzes Risk" and "Implements Risk Responses").
+- **OSHA / ISO 45001** — anchors for all safety KRIs in section 1.
+- **ISO 9001** — anchor for quality KRIs in section 4.
+- **ISO 14001 / ISO 50001 / GHG Protocol / TCFD** — environmental and climate KRIs in section 5.
+- **NIST CSF / IEC 62443 / ISO 27001** — cyber and OT KRIs in section 6.
+- **ISO 22301** — business continuity KRIs across reliability and supply chain.
+- **ISO 28000** — supply chain security KRIs.
+- **Basel-style operational risk taxonomy** — useful for manufacturers with regulated finance subsidiaries to align their operational loss event categorization.
+
+## A Starter Set: The 12 KRIs Every Manufacturer Should Track First
+
+If you are building from scratch, do not start with all 40-plus. Start with twelve and earn the right to expand:
+
+1. Total Recordable Incident Rate (TRIR)
+2. Near-miss reports per 1,000 hours worked
+3. Unplanned downtime as % of available hours
+4. Preventive maintenance completion rate
+5. % of revenue dependent on single-source suppliers
+6. Days of inventory cover for critical inputs
+7. First-pass yield
+8. Open CAPAs > 90 days
+9. Reportable environmental incidents
+10. Mean Time To Detect (MTTD) for OT anomalies
+11. Voluntary turnover among production staff
+12. Customer concentration (% revenue from top 5)
+
+This twelve-metric starter set covers safety, operations, supply chain, quality, environment, cyber, workforce, and strategy in a single dashboard. Most ERM teams can stand it up in a quarter using existing systems and a single weekly meeting cadence.
+
+## From KRI Library to KRI Program
+
+A list of metrics is not a program. A program needs governance, technology, and discipline:
+
+- **Governance** — a risk committee with defined escalation paths and a calendar. Plant-level monthly, function-level monthly, executive-level quarterly, board-level twice a year.
+- **Technology** — a GRC or ERM platform that ingests KRI feeds automatically, applies thresholds, and routes alerts. A spreadsheet works for the first 90 days; it does not scale beyond that.
+- **Discipline** — quarterly KRI review where every metric is challenged: "Is this still predictive? Is the threshold still right? Is the owner still the right person?" KRIs that fail the test get retired.
+
+Manufacturing risk is unforgiving in one specific way: most major losses are *foreseeable in the data* if anyone is watching. The companies that escape those losses are not luckier — they are the ones who turned their KRI library into a living, governed program that flags problems while there is still time to fix them.
+
+That is what a strong set of key risk indicators examples for manufacturing companies, properly implemented, gives you: time. And in modern manufacturing, time is the most valuable risk control there is.
+
+---
+
+*Looking to operationalize this KRI library inside your own ERM platform? Track each indicator with thresholds, owners, and automated alerts so red signals reach the right person before they reach the income statement.*

--- a/blog/operational-risk-key-risk-indicators-examples.md
+++ b/blog/operational-risk-key-risk-indicators-examples.md
@@ -1,0 +1,260 @@
+---
+title: "Operational Risk Key Risk Indicators Examples"
+slug: operational-risk-key-risk-indicators-examples
+target_keyword: operational risk key risk indicators
+meta_description: "A pillar guide to operational risk KRIs with 50+ examples mapped to the Basel operational risk taxonomy — covering people, process, systems, and external events, with thresholds and data sources."
+category: Enterprise Risk Management
+tags: [operational risk, KRI, Basel, ORM, internal fraud, business disruption, ERM]
+word_count: 3050
+---
+
+# Operational Risk Key Risk Indicators Examples
+
+Operational risk is the broadest and most stubborn risk category in any enterprise. It does not have a single regulator, a single owner, or a single number that tells you how exposed you are. It is the risk of loss from inadequate or failed internal processes, people, and systems, or from external events — and that definition alone covers everything from a wire fraud, to a cloud outage, to a regulator's enforcement letter, to a hurricane.
+
+The Basel Committee codified that definition for banks more than two decades ago, and the same taxonomy is now used — formally or informally — by insurers, asset managers, fintechs, healthcare systems, manufacturers, and energy companies. What makes operational risk hard is not defining it. It is *measuring* it. Loss data is sparse, severity is fat-tailed, and many of the most damaging events (the ones that make the front page) have never happened to your firm before.
+
+That is why operational risk key risk indicators matter more here than in any other risk class. Credit risk has PD, LGD, and EAD. Market risk has VaR. Operational risk has KRIs — leading metrics that track the *health of the controls* that prevent operational losses, so you can see exposure rising before it becomes a loss event.
+
+This guide collects 50-plus operational risk key risk indicators examples organized by the Basel operational risk event-type taxonomy, with thresholds, data sources, and the specific control each KRI is monitoring. It is designed to be used as a reference library when you are building or refreshing your own operational risk program.
+
+## What Operational Risk KRIs Actually Measure
+
+A key risk indicator is a quantitative metric that provides early warning of changes in risk exposure. In the operational risk context, KRIs measure one of three things:
+
+1. **Inherent risk drivers** — factors that increase the underlying exposure regardless of controls (e.g., transaction volume growth, headcount churn, new-product launches).
+2. **Control health** — whether the controls designed to mitigate the risk are functioning (e.g., reconciliation breaks, access reviews completed on time, exception approvals).
+3. **Loss precursors** — near-miss or low-severity events that, statistically, precede larger losses (e.g., near-miss fraud attempts, repeated customer complaints on the same process).
+
+The strongest operational risk programs maintain a balanced library across all three. A library full of control-health indicators will tell you whether yesterday's controls held; it will not tell you that the underlying risk environment shifted.
+
+## The Basel Operational Risk Taxonomy as the KRI Backbone
+
+The Basel framework defines seven operational risk event types. Even outside banking, this taxonomy is the most useful organizing structure for a KRI library because every operational loss can be classified into exactly one of these buckets:
+
+1. Internal Fraud
+2. External Fraud
+3. Employment Practices and Workplace Safety
+4. Clients, Products, and Business Practices
+5. Damage to Physical Assets
+6. Business Disruption and System Failures
+7. Execution, Delivery, and Process Management
+
+The rest of this article walks through KRI examples for each event type, then closes with a section on cross-cutting program-level KRIs, governance, and common implementation pitfalls.
+
+## 1. Internal Fraud KRIs
+
+Internal fraud is rare but severe — and it is one of the few operational risk classes where leading indicators consistently outperform lagging ones. The Association of Certified Fraud Examiners' biennial Report to the Nations consistently shows that median internal fraud losses scale with how long the scheme runs before detection. Every KRI in this section is, in effect, a detection-time KRI.
+
+| KRI | Threshold | Data Source | Control Monitored |
+|---|---|---|---|
+| **% of segregation-of-duties (SoD) violations open > 30 days** | < 2% | IAM / GRC | Access controls |
+| **High-risk transactions approved by a single user** | 0 | ERP / payments | Dual approval |
+| **Vacation / mandatory leave compliance for sensitive roles** | > 98% | HRIS | Mandatory leave control |
+| **Employee expense exceptions per 1,000 reports** | < 15 | T&E system | Expense policy |
+| **Whistleblower reports per 1,000 employees (annualized)** | > 0.5 (higher = healthy reporting) | Hotline | Speak-up culture |
+| **Time-to-investigate whistleblower allegations** | < 30 days median | Investigations | Triage |
+| **% of privileged finance access reviews completed on time** | 100% | IAM | UAR cycle |
+| **Manual journal entries posted by preparer-only** | 0 | GL system | Maker-checker |
+| **Vendor master changes by single user** | 0 | ERP | Vendor onboarding |
+| **Payments to newly added vendors in first 30 days (% of total)** | < 3% | AP | New-vendor scrutiny |
+
+The whistleblower KRI is counter-intuitive but well-evidenced: a sudden drop in hotline volume rarely means there is less wrongdoing — it usually means employees have lost confidence the channel works. Treat declining volume as a red flag.
+
+## 2. External Fraud KRIs
+
+External fraud now includes everything from check fraud to deepfake-enabled CEO impersonation. The KRI shift over the last five years has been from transaction-monitoring metrics to identity-and-channel metrics.
+
+| KRI | Threshold | Data Source | Control Monitored |
+|---|---|---|---|
+| **Fraud loss as bps of transaction volume** | Trending down vs baseline | Fraud system | Fraud strategy |
+| **Account takeover attempts per million logins** | < baseline + 20% | IAM / fraud | Auth controls |
+| **% of high-value wires verified via callback** | > 99% | Treasury | Callback control |
+| **Median time to detect external fraud event** | < 24 hours | Fraud system | Detection |
+| **Phishing-reported emails per 1,000 employees per month** | > 30 (higher = healthy reporting) | Email security | Awareness |
+| **Phishing simulation click rate** | < 8% | Awareness platform | Training |
+| **New-account fraud rate (first 90 days)** | < 0.3% | Onboarding | KYC / IDV |
+| **Synthetic identity flags per 1,000 applications** | Trending tracked | KYC vendor | IDV stack |
+| **Card-not-present chargeback rate** | < 0.5% | Acquirer | CNP fraud |
+| **False-positive rate on transaction monitoring** | < 95% | TMS | Rule tuning |
+
+A subtle but important pairing is the false-positive rate alongside the median detection time. A team that drives false positives down by loosening rules will see detection time drift up. Always read the two together.
+
+## 3. Employment Practices and Workplace Safety KRIs
+
+This Basel category covers HR-driven losses — discrimination claims, wrongful termination, harassment, and workplace injuries. Many firms split this category between HR and EHS owners; KRIs should still roll up to the operational risk dashboard.
+
+| KRI | Threshold | Data Source |
+|---|---|---|
+| **Open employment-related litigation cases** | Tracked, trended | Legal |
+| **EEOC / equivalent complaints per 1,000 employees** | < industry benchmark | HR / Legal |
+| **Voluntary turnover in critical roles** | < 12% annual | HRIS |
+| **Engagement survey "speak-up safety" score** | > 75% favorable | Survey tool |
+| **Total Recordable Incident Rate (TRIR)** | < 1.5 per 200,000 hours | EHS |
+| **Manager span-of-control breaches (> 12 directs)** | < 5% of managers | HRIS |
+| **% of mandatory compliance training completed** | > 98% | LMS |
+| **Open harassment investigations > 60 days** | 0 | HR / Legal |
+
+## 4. Clients, Products, and Business Practices KRIs
+
+This is the largest single Basel loss category by aggregate severity, driven by mis-selling, conduct failures, market manipulation, and inadequate disclosures. Conduct risk lives here.
+
+| KRI | Threshold | Data Source |
+|---|---|---|
+| **Customer complaints per 1,000 active accounts** | < industry benchmark | CRM |
+| **Complaints upheld by ombudsman / regulator** | Tracked | Compliance |
+| **% of complaints classified as "vulnerable customer"** | Tracked | CRM |
+| **Sales practice exceptions per 1,000 transactions** | < 5 | Sales QA |
+| **Suitability review pass rate** | > 95% | Compliance |
+| **Disclosure errors identified post-trade** | < 0.1% | Compliance |
+| **Marketing material approvals overdue** | 0 > 5 days | Marketing ops |
+| **Conflict-of-interest declarations completed on time** | 100% | Compliance |
+| **Product approval committee exceptions** | < 10% of launches | Product |
+| **% of complaints resolved within SLA** | > 95% | CX |
+
+A common mistake here is treating complaint volume as the only KRI. Complaint *mix* — the proportion tied to a single product, channel, or sales region — is usually a stronger early signal than total volume.
+
+## 5. Damage to Physical Assets KRIs
+
+This category covers losses from natural disasters, fire, vandalism, and terrorism. KRIs are mostly inherent-risk indicators and control-health indicators tied to insurance, BCM, and physical security.
+
+| KRI | Threshold | Data Source |
+|---|---|---|
+| **% of critical sites with current BIA and BCP** | 100% | BCM tool |
+| **Time since last disaster recovery test (per critical site)** | < 12 months | BCM |
+| **Insurance coverage gap vs maximum probable loss** | Tracked | Risk / Insurance |
+| **Sites in high climate-risk zones (% of asset value)** | Tracked | Property data |
+| **Physical access exception count per quarter** | < 5 per site | Physical security |
+| **CCTV / access-control system uptime** | > 99% | Facilities |
+| **Open property risk engineering recommendations** | < 10 per site | Insurer reports |
+
+## 6. Business Disruption and System Failures KRIs
+
+This is where IT, cyber, and resilience converge. With cloud concentration risk and the rise of third-party platform dependencies, this category has become the dominant source of operational losses for many firms.
+
+| KRI | Threshold | Data Source | Framework |
+|---|---|---|---|
+| **Critical system uptime** | > 99.95% | Monitoring | DORA / FFIEC |
+| **Sev-1 incidents per quarter** | < 2 | ITSM | ITIL |
+| **Mean Time To Recover (MTTR) Sev-1** | < 2 hours | ITSM | DORA |
+| **% of critical applications with tested DR plan** | > 95% | BCM | ISO 22301 |
+| **Backup restore test success rate** | > 98% | Backup logs | ISO 22301 |
+| **Change failure rate** | < 5% | DevOps | DORA Four Keys |
+| **Emergency changes as % of total** | < 10% | ITSM | Change mgmt |
+| **Patch SLA compliance — critical CVEs** | > 95% within 14 days | Vuln mgmt | NIST CSF |
+| **Mean Time To Detect (MTTD) cyber incidents** | < 4 hours | SIEM | NIST CSF |
+| **Concentration risk: % of workloads on single cloud provider** | Tracked | CMDB | DORA |
+| **Critical third-party SOC 2 / ISO 27001 reports current** | 100% | TPRM | NIST CSF |
+| **Resilience test pass rate (chaos / scenario)** | > 90% | Resilience eng | DORA |
+
+The cloud concentration KRI deserves a board conversation in its own right. Most firms cannot meaningfully reduce concentration in the short term; the KRI's purpose is to make sure leadership *knows* the exposure and has a documented response if the provider degrades.
+
+## 7. Execution, Delivery, and Process Management KRIs
+
+This is the largest category by *frequency* of loss events. Reconciliation breaks, settlement fails, mis-bookings, model errors, and data quality issues all live here. KRIs in this category are typically owned by the line of business or finance operations team.
+
+| KRI | Threshold | Data Source |
+|---|---|---|
+| **Open reconciliation breaks > 5 days** | < 50 | Recon platform |
+| **Aged break value (USD)** | < threshold per LOB | Recon |
+| **Settlement fails as % of trades** | < 1% | Operations |
+| **Failed payments per 10,000 outbound** | < 5 | Payments ops |
+| **Manual processes still in production (count)** | Trending down | Process inventory |
+| **Process exceptions per 1,000 transactions** | < 10 | Workflow |
+| **Data quality score on critical data elements** | > 95% | DQ tool |
+| **% of EUC (end-user computing) tools registered and reviewed** | > 90% | EUC inventory |
+| **Open audit findings past due date** | < 5 | Audit |
+| **Self-identified issues vs audit-identified (ratio)** | > 2:1 | RCSA / Audit |
+| **Model risk: models past validation due date** | 0 | Model inventory |
+| **Vendor SLA breaches per quarter** | < threshold per critical vendor | TPRM |
+
+The self-identified vs audit-identified ratio is one of the most underused KRIs in operational risk. A healthy program finds at least twice as many issues itself as audit finds for it. A ratio under 1:1 means the first line is not actively risk-managing.
+
+## Cross-Cutting Program-Level KRIs
+
+Beyond the seven event-type buckets, there is a small set of program-level KRIs that measure the *health of the operational risk function itself*. These should sit on every CRO's dashboard.
+
+| KRI | Threshold |
+|---|---|
+| **% of business units with completed RCSA in last 12 months** | 100% |
+| **% of top risks with KRI coverage** | > 90% |
+| **% of KRIs in red status > 90 days** | < 10% |
+| **% of risk events captured in loss database within 30 days** | > 95% |
+| **Unreported losses identified by audit / regulator** | 0 |
+| **Risk appetite breaches per quarter** | Tracked, trended |
+| **Time to close issues by severity** | Within agreed SLA |
+| **Coverage of key business processes by control testing** | > 80% annual |
+
+If your operational risk program does not measure itself, it is not a program — it is a collection of dashboards.
+
+## Building Thresholds That Actually Trigger Action
+
+A KRI without a threshold is a statistic. The most common mistake is choosing thresholds based on intuition or last year's performance. Mature programs use one of three threshold-setting methods:
+
+1. **Statistical baselining** — calculate the rolling 12-month mean and standard deviation, set amber at +1σ and red at +2σ. Works well for high-frequency KRIs (transaction volumes, complaints, login attempts).
+2. **Risk appetite cascade** — start with the board-approved appetite statement (e.g., "no operational loss event exceeding USD X"), translate to KRI thresholds that, if breached, would put the appetite at risk.
+3. **Regulatory or framework benchmark** — for KRIs with external reference points (TRIR, SLA targets in DORA, RTO/RPO in BCM standards), use the external benchmark as the red threshold and a tighter internal level as the amber.
+
+Whichever method you use, *write down* how the threshold was set and review it annually. A threshold no one can defend will be debated every time it is breached, which is exactly when you do not want a debate.
+
+## Governance: Turning KRIs Into Decisions
+
+A KRI library produces a number; a governance process produces a decision. The minimum viable governance for an operational risk KRI program looks like this:
+
+- **Weekly** — first-line risk owners review their KRIs and act on amber/red signals.
+- **Monthly** — second-line operational risk function aggregates KRIs, challenges the first line, and reviews trends.
+- **Quarterly** — executive risk committee reviews enterprise KRI dashboard, appetite breaches, and emerging risks.
+- **Semi-annually** — board risk committee reviews program-level KRIs and the effectiveness of the operational risk function itself.
+- **Annually** — KRI library is recalibrated. Indicators that were green for four straight quarters are pressure-tested. Indicators that were red for two straight quarters are escalated to a remediation program.
+
+The key word is *decision*. Every KRI report should explicitly state, for every red and amber indicator: who owns it, what action is being taken, and by when. A report that simply lists numbers is not governance.
+
+## Common Implementation Pitfalls
+
+Even well-funded programs run into the same problems. The fastest way to mature an operational risk KRI program is to actively avoid them:
+
+- **Library bloat.** Programs with 300+ KRIs usually run no real KRIs at all. Most enterprises operate with 50–100 enterprise-level operational risk KRIs and similar numbers at the LOB level. More than that and the signal is lost in the noise.
+- **All control-health, no inherent-risk.** A library that only measures whether controls fired tells you nothing about whether the underlying environment shifted. Always carry inherent-risk indicators (transaction volume growth, new-product launches, headcount churn).
+- **No link to RCSA.** KRIs and Risk and Control Self-Assessments (RCSAs) should be the same conversation. The RCSA identifies the top risks; the KRIs measure them. If your RCSA outputs and KRI library do not reference each other, they are running in parallel — and that costs credibility with the board.
+- **Manual data feeds.** A KRI that depends on someone exporting a CSV every Monday will not survive a reorganization. Automate at the source.
+- **No connection to capital or appetite.** Especially in regulated firms, KRIs should feed into operational risk capital models (SMA inputs, scenario analysis) and the firm's stated risk appetite. KRIs that float free of those processes get ignored.
+- **No retirement discipline.** A library that only grows is a library that gets ignored. Retire indicators that no longer move, no longer matter, or duplicate other indicators.
+- **Confusing KPIs with KRIs.** Operations leaders often want their KPIs included in the KRI library. Resist. KPIs measure performance against plan; KRIs measure exposure against appetite. Both matter; they are not the same.
+
+## A Starter Set: 15 KRIs to Anchor a New Operational Risk Program
+
+If you are building from scratch — or trying to rationalize a bloated library — start with these fifteen. Together they cover all seven Basel event types and the program itself:
+
+1. SoD violations open > 30 days (Internal Fraud)
+2. Whistleblower reports per 1,000 employees (Internal Fraud)
+3. Median time to detect external fraud event (External Fraud)
+4. Phishing simulation click rate (External Fraud)
+5. Open employment-related litigation cases (Employment Practices)
+6. Customer complaints upheld by regulator (Clients & Products)
+7. % of critical sites with tested BCP (Damage to Assets)
+8. Critical system uptime (Business Disruption)
+9. MTTR Sev-1 incidents (Business Disruption)
+10. Patch SLA compliance — critical CVEs (Business Disruption)
+11. Open reconciliation breaks > 5 days (Execution)
+12. Self-identified vs audit-identified issues ratio (Execution)
+13. % of top risks with KRI coverage (Program)
+14. % of KRIs in red status > 90 days (Program)
+15. Risk appetite breaches per quarter (Program)
+
+Stand these up first. Earn the right — through clean data, on-time reporting, and demonstrated decision impact — to expand the library from there.
+
+## Closing Thought: Operational Risk KRIs Are a Forecasting Discipline
+
+The reason operational risk KRIs feel harder than credit or market KRIs is that there is no neat closed-form model behind them. You are not solving a mathematical equation; you are building a sensor network across the enterprise that, in aggregate, lets the CRO and board see exposure forming before it becomes a loss.
+
+The firms that do this well share three habits:
+
+1. They treat the KRI library as a living artifact and review it relentlessly.
+2. They link every red indicator to a specific decision and a named owner.
+3. They use the program itself as a KRI — measuring whether their operational risk function is actually changing outcomes.
+
+A well-built set of operational risk key risk indicators is not just a regulatory deliverable. It is the early-warning system that keeps the firm out of the headlines, the loss database, and the enforcement queue. And in a risk class as broad and unforgiving as operational risk, that early-warning system is the single highest-leverage investment a risk function can make.
+
+---
+
+*Want to operationalize this KRI library? Track each indicator with thresholds, owners, and automated alerts inside a single ERM platform — and link every red signal to a documented response action so KRIs translate into decisions, not just dashboards.*


### PR DESCRIPTION
## Summary

Generated two blog posts from the content calendar, both at the high-priority tier and each mirroring a top-performing template:

- **`blog/key-risk-indicators-examples-for-manufacturing-companies.md`** — Pattern A (industry vertical), ~2,900 words. Targets `key risk indicators examples for manufacturing`. Anchored to OSHA, ISO 31000, ISO 45001, ISO 9001, ISO 14001, NIST CSF, and IEC 62443 per the calendar's notes column.
- **`blog/operational-risk-key-risk-indicators-examples.md`** — Pattern B (risk type pillar), ~3,050 words. Targets `operational risk key risk indicators`. Organized around the seven Basel operational risk event types as the calendar specified.

Each post includes:
- A 40–50 KRI library with thresholds, data sources, and framework anchors
- Lead vs. lag balance with worked examples
- A 12–15 KRI starter set for teams building from scratch
- Governance cadence (weekly/monthly/quarterly/board) and common implementation pitfalls

## Test plan

- [ ] Editorial review for tone, accuracy, and house style
- [ ] SEO check: target keyword density, meta description length, H2/H3 hierarchy
- [ ] Verify framework references (OSHA, ISO, Basel, NIST) match internal citations
- [ ] Confirm CTA in each post matches current product positioning
- [ ] Render Markdown tables in the target CMS

https://claude.ai/code/session_011WA4G34Jgo5xXP5JBVhga3

---
_Generated by [Claude Code](https://claude.ai/code/session_011WA4G34Jgo5xXP5JBVhga3)_