### PR TITLE
Add two KRI blog posts: manufacturing industry and operational risk

### DIFF
--- a/blog/key-risk-indicators-examples-for-manufacturing-companies.md
+++ b/blog/key-risk-indicators-examples-for-manufacturing-companies.md
@@ -1,0 +1,252 @@
+---
+title: "Key Risk Indicators Examples for Manufacturing Companies"
+slug: key-risk-indicators-examples-for-manufacturing-companies
+target_keyword: key risk indicators examples for manufacturing
+meta_description: "A practical guide to Key Risk Indicators (KRIs) for manufacturing companies. 40+ KRI examples across safety, quality, supply chain, and operations with formulas and thresholds."
+word_count: ~2,800
+category: Industry KRIs
+---
+
+# Key Risk Indicators Examples for Manufacturing Companies
+
+A single defective batch, an unplanned line stoppage, or a missed shipment can cost a manufacturer millions, sometimes overnight. Unlike service businesses, manufacturers carry the weight of physical assets, hazardous processes, complex supply chains, and tight regulatory oversight from bodies such as OSHA, the EPA, ISO, and industry-specific regulators. That weight is exactly why **Key Risk Indicators (KRIs)** matter so much on the plant floor.
+
+Yet most manufacturers still rely on lagging metrics – injuries that already happened, recalls already issued, suppliers that already failed. By the time those numbers move, the damage is done. KRIs flip the script: they are leading signals that warn you before risk becomes loss.
+
+This guide walks through what KRIs are, why they are different in a manufacturing context, and gives you more than 40 ready-to-use **key risk indicators examples for manufacturing** – complete with formulas, thresholds, and the data sources you will need to track them.
+
+## What Is a Key Risk Indicator?
+
+A Key Risk Indicator is a measurable, forward-looking metric that signals a change in the level of exposure to a specific risk. Think of a KRI as the dashboard warning light in your car: it does not tell you the engine has failed, it tells you that pressure or temperature is moving toward the point where failure becomes likely.
+
+Three traits separate a true KRI from an ordinary KPI:
+
+1. **It is leading, not lagging.** A KRI moves *before* the loss event.
+2. **It has thresholds.** Green, amber, and red bands trigger defined actions.
+3. **It is tied to a specific risk.** A KRI without a parent risk is just a number.
+
+In a manufacturing context, KRIs sit alongside KPIs like OEE (Overall Equipment Effectiveness) and First-Pass Yield, but they answer a different question: *what could go wrong, and is the probability rising?*
+
+## Why Manufacturing Needs KRIs More Than Most Industries
+
+Four characteristics of manufacturing make KRIs uniquely valuable:
+
+- **Asset intensity.** A single CNC machine, press line, or reactor can represent millions of dollars and weeks of replacement lead time.
+- **Safety exposure.** OSHA recordable incidents, hazardous chemicals, confined spaces, and lockout/tagout failures all create direct human and legal liability.
+- **Supply chain fragility.** Tier-2 and tier-3 supplier disruptions, single-source components, and just-in-time inventory leave little buffer.
+- **Regulatory complexity.** ISO 9001, ISO 14001, ISO 45001, FDA 21 CFR Part 820, IATF 16949, REACH, RoHS, and conflict minerals reporting overlap and compound penalties when missed.
+
+A well-designed KRI program turns each of these pressure points into a number you can watch trend by trend.
+
+## How Manufacturing KRIs Are Categorized
+
+To make a KRI library usable, group indicators by the risk family they monitor. The taxonomy below mirrors the way most ERM frameworks (COSO, ISO 31000) treat manufacturing:
+
+1. Safety and Occupational Health Risk
+2. Operational and Equipment Risk
+3. Quality and Product Risk
+4. Supply Chain Risk
+5. Environmental, Health, and Sustainability (EHS) Risk
+6. Cybersecurity and OT Risk
+7. Workforce Risk
+8. Financial and Commercial Risk
+9. Regulatory and Compliance Risk
+
+The next nine sections give you concrete KRI examples for each category.
+
+## 1. Safety and Occupational Health KRIs
+
+Safety is the highest-stakes category. The KRIs below align with OSHA recordkeeping and ISO 45001.
+
+| KRI | Formula | Suggested Amber / Red Threshold |
+|---|---|---|
+| **Total Recordable Incident Rate (TRIR)** | (Recordable injuries × 200,000) / Total hours worked | Amber: ≥ industry median, Red: ≥ 75th percentile |
+| **Lost Time Injury Frequency Rate (LTIFR)** | (Lost-time injuries × 1,000,000) / Total hours worked | Amber: ≥ 2.0, Red: ≥ 4.0 |
+| **Near-Miss Reporting Ratio** | Near-misses reported / Recordable incidents | Below 10:1 is a red flag (under-reporting) |
+| **Behavior-Based Safety Observation Closure Rate** | Observations closed within 14 days / Total observations | Amber: < 85%, Red: < 70% |
+| **% Employees Overdue on Mandatory Safety Training** | Overdue employees / Required population | Amber: > 5%, Red: > 10% |
+| **Lockout/Tagout (LOTO) Audit Failure Rate** | Failed LOTO audits / Total audits | Amber: > 3%, Red: > 7% |
+| **PPE Non-Compliance Observations per Shift** | Count of PPE violations per shift | Amber: > 3, Red: > 6 |
+
+Counter-intuitive insight: a *rising* near-miss reporting rate is almost always a *good* sign. It means workers trust the system enough to report. A flat or falling number while production volume rises is the warning.
+
+## 2. Operational and Equipment KRIs
+
+These KRIs watch the assets that turn raw material into product. Many integrate directly with your CMMS or MES.
+
+- **Unplanned Downtime Hours per Asset** – flag any asset trending above its 90-day moving average by more than 20%.
+- **Mean Time Between Failures (MTBF)** – falling MTBF on a critical line is one of the strongest leading signals you have.
+- **Mean Time to Repair (MTTR)** – rising MTTR usually signals a skills gap or spare-parts shortage.
+- **% of Critical Spares Below Minimum Stock** – red threshold: > 5% of A-class spares.
+- **Preventive Maintenance Compliance** – PMs completed on schedule / PMs scheduled. Anything below 90% is a red flag.
+- **Calibration Overdue Rate** – instruments past calibration due date / total instruments. Red: > 2%.
+- **Asset Condition Index (ACI)** – composite score from vibration, thermography, oil analysis. Trending ACI is more useful than absolute value.
+- **Unplanned vs Planned Maintenance Ratio** – a healthy ratio is roughly 20:80 unplanned to planned. Drifting toward 50:50 is a warning.
+
+## 3. Quality and Product Risk KRIs
+
+These KRIs are essential for IATF 16949 (automotive), AS9100 (aerospace), and FDA-regulated environments.
+
+- **First-Pass Yield (FPY)** – a falling FPY on a specific line over three consecutive shifts is a leading recall indicator.
+- **Customer Complaint Rate** – complaints per million units shipped (CPM).
+- **PPM (Parts per Million) Defective at Customer** – red threshold often defined contractually by OEM customers.
+- **Cost of Poor Quality (COPQ) as % of Revenue** – internal + external failure cost. Industry benchmark is 1–3%; >5% is red.
+- **Open CAPAs Past Due Date** – critical for FDA, ISO, and IATF audits.
+- **Supplier Quality Defect Rate** – PPM from incoming inspection.
+- **Recall Risk Index** – composite of severity × occurrence × detectability across active SKUs.
+- **% of Production Runs With Out-of-Spec SPC Signals** – statistical process control trips per shift.
+
+A practical tip: pair every quality KRI with a *time-to-detect* KRI. Two plants with the same defect rate are not equally risky if one detects in 15 minutes and the other in 15 hours.
+
+## 4. Supply Chain KRIs
+
+Post-2020, supply chain risk is no longer a back-office concern – it is a board-level KRI category.
+
+| KRI | Why It Matters |
+|---|---|
+| **% Single-Source Critical Components** | Concentrated dependency = catastrophic stoppage risk |
+| **Supplier On-Time-In-Full (OTIF)** | A 5-point drop usually precedes line stoppages within 30 days |
+| **Days of Inventory on Hand for Critical Materials** | Below 7 days for a 30-day lead-time item = red |
+| **Supplier Financial Health Score** (Dun & Bradstreet, RapidRatings) | Predicts supplier insolvency 6–12 months ahead |
+| **Geographic Concentration of Tier-1 Spend** | > 30% in one country = amber, > 50% = red |
+| **% Suppliers Without an Up-to-Date Code of Conduct Acknowledgement** | Compliance and ESG exposure |
+| **Logistics Lead-Time Variance** | Standard deviation of inbound transit times |
+| **% PO Lines With Past-Due Promise Dates** | Operational early warning |
+
+## 5. Environmental, Health, and Sustainability KRIs
+
+Driven by ISO 14001, EPA permits, and increasingly by CSRD and SEC climate disclosure.
+
+- **Number of Environmental Permit Exceedances (YTD)**
+- **Hazardous Waste Generated per Unit of Output**
+- **Scope 1 + 2 Emissions Intensity (tCO₂e per $M revenue or per ton produced)**
+- **Water Withdrawal in Water-Stressed Locations**
+- **% Sites With an ISO 14001 Audit Finding Open > 90 Days**
+- **Spill Frequency Rate** – number of reportable spills per 200,000 hours worked
+- **Energy Consumption Variance vs Plan**
+- **Days to Submit Required Environmental Reports** – missing a Toxic Release Inventory (TRI) deadline carries fixed-dollar penalties.
+
+## 6. Cybersecurity and OT KRIs
+
+Modern manufacturing plants run on ICS, SCADA, and IIoT – which means OT now has the same risk profile IT had 15 years ago. These KRIs sit alongside (not inside) your standard IT cyber KRIs.
+
+- **% OT Assets With Unsupported / End-of-Life Operating Systems**
+- **% PLCs and HMIs With Default Passwords Still Active**
+- **Number of Unauthorized USB Connections to OT Network per Month**
+- **Mean Time to Detect (MTTD) on OT Network**
+- **% OT Network Segments Without Documented Segmentation**
+- **Vendor Remote Access Sessions Without MFA**
+- **Patch Latency on Internet-Facing OT Gateways**
+- **Ransomware Tabletop Exercise Frequency** (per facility, per year)
+
+If you can only track three OT KRIs, start with EOL OS coverage, default credentials, and remote-access MFA. They cover roughly 70% of the actual breach pathways seen in manufacturing incidents.
+
+## 7. Workforce KRIs
+
+Skilled-labor shortage is now a top-five risk for most US and EU manufacturers.
+
+- **Voluntary Turnover Rate (Critical Roles)** – press operators, maintenance techs, quality engineers
+- **Average Tenure in Critical Roles**
+- **% Open Critical Roles > 60 Days**
+- **Overtime as % of Total Hours** – sustained > 15% predicts both safety and quality incidents
+- **Absenteeism Rate by Shift**
+- **Skill Matrix Coverage** – % of critical tasks with at least two qualified operators
+- **Training Hours per FTE**
+
+## 8. Financial and Commercial KRIs
+
+These KRIs link plant performance to financial exposure.
+
+- **Customer Concentration** – % revenue from top 3 customers
+- **Working Capital Days (DSO + DIO – DPO)**
+- **Foreign Exchange Exposure as % of Revenue**
+- **Commodity Price Variance vs Hedged Position**
+- **Backlog Coverage (months)** – falling backlog is a leading indicator for layoffs and idle capacity
+- **Margin Compression by Product Line**
+- **% of Contracts Without Force Majeure / Pass-Through Clauses**
+
+## 9. Regulatory and Compliance KRIs
+
+- **Number of Open Regulatory Findings (OSHA, EPA, FDA, USDA, etc.)**
+- **Days to Close Regulatory Findings**
+- **% of Sites Overdue on Mandatory Reporting (TRI, EEO-1, Form R)**
+- **Conflict Minerals Reporting Coverage**
+- **Customs Compliance Error Rate**
+- **% Suppliers Screened Against Sanctions Lists in Last 90 Days**
+- **REACH / RoHS Substance-of-Concern Exposure**
+
+## Setting Thresholds: The 70/85/95 Approach
+
+A KRI without a threshold is just a chart. A simple rule of thumb that works well in manufacturing:
+
+- **Green:** KRI is within historical norm (e.g., last 12-month rolling average ± 1 standard deviation).
+- **Amber:** KRI breaches the 85th percentile of its 12-month distribution.
+- **Red:** KRI breaches the 95th percentile, *or* sits in amber for three consecutive periods.
+
+Each band must have a pre-defined action: green = monitor, amber = root-cause review at next ops meeting, red = formal escalation to risk committee within 48 hours. Without the action mapping, you have a dashboard, not a control.
+
+## Linking KRIs to Risks: A Worked Example
+
+Take the risk **"Unplanned line stoppage on the high-speed packaging line."**
+
+| Driver | KRI | Threshold |
+|---|---|---|
+| Equipment wear | MTBF on packer | Red < 240 hours |
+| Spare-parts shortage | Critical spares stockout days YTD | Red > 5 |
+| Operator error | New-hire % on shift | Red > 30% |
+| Supplier failure | Film supplier OTIF | Red < 90% |
+| Cyber/OT | EOL OS on packer HMI | Red = any |
+
+Five KRIs, one risk. When two or more flip amber simultaneously, you have an early warning that no single KPI would catch.
+
+## Common Pitfalls When Implementing Manufacturing KRIs
+
+1. **Tracking too many.** A plant can act on 15–25 KRIs. A library of 200 becomes shelfware.
+2. **Confusing KPIs with KRIs.** OEE is a KPI. *Trend in OEE variance* is a KRI.
+3. **Manual data collection.** If a KRI requires a human to compile a spreadsheet weekly, it will silently die. Pull from MES, CMMS, ERP, and EHS systems automatically.
+4. **No owner.** Every KRI needs a named accountable owner who is empowered to act.
+5. **Static thresholds.** Re-baseline thresholds every 12 months as processes mature.
+6. **Reporting up only.** KRIs are most powerful when they go *down* to the line supervisor in real time, not just up to the C-suite quarterly.
+
+## A 90-Day Roadmap to Stand Up a Manufacturing KRI Program
+
+- **Days 1–15:** Risk identification workshop with operations, EHS, quality, supply chain, finance, and IT/OT.
+- **Days 15–30:** Map top 15 enterprise risks to candidate KRIs from the categories above.
+- **Days 30–45:** Wire data sources (MES, CMMS, ERP, EHS, HRIS) into a single reporting layer – Power BI, Tableau, or a purpose-built GRC tool.
+- **Days 45–60:** Set provisional thresholds using 12 months of historical data. Validate with plant managers.
+- **Days 60–75:** Define escalation playbooks for amber and red. Train owners.
+- **Days 75–90:** Run the first formal monthly KRI review at the risk committee. Iterate.
+
+By the end of 90 days, a mid-size manufacturer can typically have a 20-KRI dashboard refreshed daily with clear ownership and escalation paths.
+
+## Industry-Specific Considerations: Tailoring KRIs to Your Sub-Sector
+
+Manufacturing is not monolithic. The KRI mix shifts meaningfully across sub-sectors:
+
+- **Automotive (IATF 16949):** PPM defective at customer, Supplier OTIF, and warranty claim cost per vehicle dominate the dashboard. OEM customers will often *contractually* set red thresholds for you.
+- **Aerospace (AS9100):** First-Article Inspection failure rate, special-process certification expiries, and counterfeit-part detection events are non-negotiable additions.
+- **Food and Beverage (FSMA, FSSC 22000):** Foreign-body detection rate, allergen cross-contact incidents, microbial test failure rate, and traceability test recovery time become tier-1 KRIs.
+- **Pharmaceutical and Medical Device (21 CFR 210/211, 820):** Deviation rate per batch, OOS (out-of-specification) results trend, CAPA closure cycle time, and data-integrity audit findings are the regulator's first questions.
+- **Chemicals (REACH, OSHA PSM):** Process Safety Management element compliance, mechanical integrity inspection backlog, and Tier 1 / Tier 2 process safety events per API RP 754.
+- **Heavy Industry / Steel / Cement:** Energy consumption per ton, emissions intensity, and unplanned outage hours on critical assets carry outsized financial weight.
+
+The principle is simple: start from the regulatory and customer regimes that bind your sub-sector, then layer on the cross-cutting KRIs from the categories above.
+
+## Tooling: What Actually Carries a KRI Programme
+
+A KRI programme lives or dies on its data plumbing. Most mature manufacturers settle on a stack roughly like this:
+
+- **Source systems:** MES (Wonderware, Ignition, Rockwell), CMMS (Maximo, SAP PM, Fiix), ERP (SAP, Oracle, Microsoft), EHS (Intelex, Cority, Sphera), QMS (MasterControl, ETQ), HRIS (Workday, SuccessFactors), and OT monitoring (Claroty, Nozomi, Dragos).
+- **Aggregation layer:** A data lake or warehouse (Snowflake, Databricks, Synapse) with curated risk marts.
+- **Reporting / GRC layer:** Power BI or Tableau for operational dashboards; a GRC tool (Archer, ServiceNow IRM, LogicGate, MetricStream, Riskonnect) for the formal risk register and KRI library.
+- **Workflow:** Tickets and escalations routed through ServiceNow, Jira, or the GRC tool itself, with SLA timers attached to amber/red breaches.
+
+You do not need every tool above on day one. You *do* need a single source of truth per KRI and an automated feed.
+
+## Final Word
+
+Manufacturing risk does not care about quarterly reviews. Equipment fails on the night shift, suppliers go bankrupt over a long weekend, and OSHA inspectors arrive without an appointment. The plants that absorb those shocks best are the ones that watch the **leading** signals – the KRIs – not the lagging ones.
+
+Pick five KRIs from this guide that map to your three biggest risks. Wire them to live data. Set thresholds. Define what happens when red flashes. Do that, and you will have done more for your risk posture than another 50-page policy document ever could.
+
+The next time someone in your organization says "no one saw it coming," you will be able to say, truthfully, that *you* did.

--- a/blog/operational-risk-key-risk-indicators-examples.md
+++ b/blog/operational-risk-key-risk-indicators-examples.md
@@ -1,0 +1,322 @@
+---
+title: "Operational Risk Key Risk Indicators Examples"
+slug: operational-risk-key-risk-indicators-examples
+target_keyword: operational risk key risk indicators
+meta_description: "The complete pillar guide to Operational Risk KRIs: Basel-aligned definitions, 50+ KRI examples across people, process, systems, and external events, with formulas and thresholds."
+word_count: ~3,100
+category: Risk-Type KRIs (Pillar)
+---
+
+# Operational Risk Key Risk Indicators Examples
+
+Of all the risk categories an enterprise faces, operational risk is the most pervasive – and the hardest to measure. Credit risk has a borrower. Market risk has a price. Liquidity risk has a balance sheet. Operational risk has *everything else*: the failed payment file, the rogue trader, the ransomware locker, the burst water pipe, the misfiled regulatory return.
+
+That breadth is exactly why **operational risk Key Risk Indicators (KRIs)** are non-negotiable. You cannot watch every process, but you can watch the *signals* that tell you a process is drifting toward failure. This pillar guide gives you Basel-aligned definitions, a category-by-category KRI library, formulas, thresholds, and an implementation playbook you can put to work this quarter.
+
+## What Is Operational Risk?
+
+The Basel Committee on Banking Supervision defines operational risk as:
+
+> "The risk of loss resulting from inadequate or failed internal processes, people and systems, or from external events. This definition includes legal risk but excludes strategic and reputational risk."
+
+That definition – now the global standard well beyond banking – splits operational risk into four sources:
+
+1. **People** – fraud, error, key-person dependency, conduct, capacity
+2. **Process** – broken workflows, manual workarounds, control failures
+3. **Systems** – outages, cyber breaches, data integrity, third-party platforms
+4. **External events** – natural disasters, pandemics, geopolitical shocks, vendor failures
+
+Every operational risk KRI you design should map cleanly to one (or sometimes two) of those four buckets.
+
+## What Makes a KRI a *Key* Risk Indicator?
+
+A KRI is not just any metric. To qualify as a true KRI – and to earn space on a senior leadership dashboard – it must satisfy five tests:
+
+1. **Leading.** It moves *before* the loss event, not after.
+2. **Measurable.** It has an unambiguous formula and a reliable data source.
+3. **Linked.** It maps to a specific named risk, not a general topic.
+4. **Threshold-bounded.** Green, amber, and red bands are defined in advance.
+5. **Actionable.** Each threshold breach triggers a pre-agreed action.
+
+A KPI without those five traits is just a number. A number without those five traits is just noise.
+
+## Why Operational Risk KRIs Matter More Than Ever
+
+Three forces have raised the stakes:
+
+- **Basel III/IV finalised the Standardised Measurement Approach (SMA),** under which a bank's operational risk capital is driven directly by historical losses. Every operational loss event now has a multi-year capital tail.
+- **Regulators expect operational resilience.** The UK PRA, EU DORA, US OCC, and APRA CPS 230 all now mandate that firms identify *important business services*, set *impact tolerances*, and *test* their ability to stay within them. KRIs are the day-to-day instrument of those regimes.
+- **Operational losses are growing faster than balance sheets.** ORX consortium data shows operational loss frequency has risen markedly since 2018, driven by cyber, third-party, and conduct events.
+
+Boards no longer accept "we monitor operational risk qualitatively." They expect numbers, on a dashboard, with thresholds.
+
+## How to Categorize Operational Risk KRIs
+
+The cleanest taxonomy is the Basel Level-1 event-type taxonomy, which most ERM teams adapt as follows:
+
+1. **Internal Fraud**
+2. **External Fraud**
+3. **Employment Practices and Workplace Safety**
+4. **Clients, Products, and Business Practices (Conduct)**
+5. **Damage to Physical Assets**
+6. **Business Disruption and System Failures (Technology / Cyber)**
+7. **Execution, Delivery, and Process Management**
+8. **Third-Party / Outsourcing**
+9. **Change and Project Risk**
+10. **People and Culture**
+
+The next ten sections give you concrete operational risk KRI examples for each.
+
+## 1. Internal Fraud KRIs
+
+| KRI | Formula | Suggested Red Threshold |
+|---|---|---|
+| **Number of staff with segregation-of-duties (SoD) conflicts** | Count of users whose role bundle violates SoD policy | Any unmitigated conflict on a financial system |
+| **% privileged access reviews overdue** | Overdue reviews / Total reviews due | > 5% |
+| **Whistleblower reports per 1,000 FTE** | Reports received / FTE × 1,000 | A *falling* number is often the red flag, not a rising one |
+| **Dormant employee accounts still active** | Accounts not used > 60 days but not disabled | > 1% of workforce |
+| **Manual journal entries above materiality posted by single approver** | Count per month | Any non-zero value warrants review |
+
+## 2. External Fraud KRIs
+
+- **Fraud losses as % of revenue** (split by channel: card-present, card-not-present, ACH, wire)
+- **First-party fraud rate** on new accounts
+- **Authorised Push Payment (APP) fraud loss per £1m of payment volume**
+- **% transactions flagged but auto-approved** (suppressed alert rate)
+- **Account takeover incidents per 100,000 active accounts**
+- **Synthetic identity detection rate**
+
+The single most predictive external fraud KRI in payments is the *velocity of failed authentication attempts per 1,000 sessions* – a 20% week-over-week rise typically precedes a coordinated attack by 7 to 14 days.
+
+## 3. Employment Practices and Workplace Safety KRIs
+
+- **Lost-Time Injury Frequency Rate (LTIFR)** – injuries × 1m / hours worked
+- **Open employment-related claims** (harassment, discrimination, wage)
+- **Employment claim settlement cost YTD vs budget**
+- **% mandatory training overdue** (anti-bribery, code of conduct, health & safety)
+- **Engagement survey response rate** – falling response rate is itself a KRI
+- **Voluntary turnover in critical roles**
+
+## 4. Conduct and Clients/Products KRIs
+
+These KRIs are central to FCA, ASIC, and CFPB-style conduct regimes.
+
+- **Complaints per 1,000 customers** (split by product, root cause, vulnerability flag)
+- **% complaints upheld by ombudsman / regulator**
+- **Mis-selling indicators**: % sales reversed within 14-day cooling-off window
+- **% customer interactions reviewed under QA framework**
+- **Sales-incentive risk score** – proportion of variable comp tied to single product
+- **Vulnerable customer identification rate** vs portfolio expectation
+
+## 5. Damage to Physical Assets KRIs
+
+- **Number of sites in flood / earthquake / wildfire zones above tolerance**
+- **% sites with current Business Impact Analysis (BIA)**
+- **% sites with tested evacuation plan in last 12 months**
+- **Insurance coverage gap (insured value vs replacement cost)**
+- **Property loss frequency per 100 sites**
+
+## 6. Technology, Cyber, and Business Disruption KRIs
+
+This is the fastest-growing category and deserves the deepest library.
+
+### Availability and resilience
+
+- **% Important Business Services breaching impact tolerance YTD** (DORA / PRA SS1/21)
+- **Number of P1/P2 incidents per quarter**
+- **Mean Time to Recover (MTTR)** for tier-1 services
+- **% disaster recovery tests passed in last 12 months**
+- **Recovery Time Objective (RTO) achievement rate**
+- **% applications without a tested DR plan**
+
+### Change and release
+
+- **Change failure rate** – failed changes / total changes
+- **% emergency changes vs total changes** (sustained > 15% is a red flag)
+- **Rollback rate by release**
+
+### Cyber
+
+- **Mean Time to Detect (MTTD)** – critical alerts only
+- **% critical vulnerabilities unpatched > SLA** (e.g., 30 days)
+- **% privileged accounts without MFA**
+- **Phishing simulation click rate**
+- **% systems with EOL operating systems**
+- **Number of confirmed data exfiltration events**
+- **DLP alerts per 1,000 employees**
+
+### Data and integrity
+
+- **% critical data elements without an owner**
+- **Data quality issues open > SLA**
+- **% systems without immutable backups**
+
+## 7. Execution, Delivery, and Process Management KRIs
+
+Often the largest single source of operational losses by volume.
+
+- **Manual workaround count** – processes still requiring spreadsheet patches
+- **Reconciliation breaks open > 5 days**
+- **Failed trade rate** (in capital markets) or **failed payment rate** (in banking/payments)
+- **% transactions requiring manual repair**
+- **STP (straight-through processing) rate** – falling STP signals process erosion
+- **% controls untested in last 12 months**
+- **Issues raised by audit / second line still open past due date**
+- **Backlog ageing** – count of items > 30 days old in core operations queues
+
+## 8. Third-Party and Outsourcing KRIs
+
+Post-DORA and OCC 2023-17 third-party guidance, this category is now scrutinised at board level.
+
+- **% material third parties without current due diligence**
+- **% material third parties without exit / substitutability plan**
+- **Concentration risk** – % critical services sourced from a single provider
+- **Fourth-party visibility coverage** – % material vendors with disclosed sub-contractors
+- **Vendor SLA breach rate**
+- **Vendor financial health score** (RapidRatings, D&B)
+- **Days to offboard a terminated vendor's access**
+
+## 9. Change and Project Risk KRIs
+
+- **% strategic projects rated red on RAG status**
+- **Schedule variance > 20% on tier-1 programmes**
+- **Cost variance > 15% on tier-1 programmes**
+- **Benefits realisation gap** – planned vs realised business case
+- **Change saturation index** – number of concurrent major changes hitting the same business unit
+
+## 10. People and Culture KRIs
+
+- **Risk culture survey score**
+- **% leaders completing risk training**
+- **Incident reporting rate** – low and falling = under-reporting culture
+- **Speak-up index** – calls to ethics line per 1,000 FTE
+- **Span of control outliers** – managers with > 12 direct reports
+
+## Quantitative vs Qualitative KRIs
+
+Strong programmes use both:
+
+- **Quantitative KRIs** – numeric, formula-driven (e.g., MTTD, fraud loss per £1m).
+- **Qualitative KRIs** – assessed on a scale (e.g., risk culture survey score, control self-assessment ratings).
+
+Qualitative KRIs are not "soft" – they are often the earliest signals of trouble. The Wells Fargo, Barings, and Société Générale cases all featured deteriorating *cultural* indicators long before quantitative losses showed up.
+
+## Setting Thresholds: A Practical Framework
+
+Avoid the temptation to set thresholds by gut. A repeatable approach:
+
+1. **Pull 24 months of history** for each candidate KRI.
+2. **Calculate the 50th, 85th, and 95th percentiles** of the distribution.
+3. **Set Green = below 50th, Amber = 50th–85th, Red = above 85th.** Adjust where regulatory or contractual limits override.
+4. **Re-baseline annually** to prevent drift.
+5. **Document the mathematical basis** so internal audit can challenge it.
+
+For low-frequency / high-severity KRIs (e.g., critical regulatory breaches), thresholds are usually *count-based*: red = 1, amber = potential / near-miss = 1.
+
+## Linking KRIs to the Risk Taxonomy
+
+Every KRI should sit in a chain:
+
+> **Risk → Control → KRI → Threshold → Action → Owner**
+
+Worked example for "Unauthorised payment release":
+
+| Element | Value |
+|---|---|
+| Risk | Unauthorised payment release |
+| Key Control | Dual approval on payments > $50,000 |
+| KRI 1 | % payments > $50k released without dual approval |
+| KRI 2 | Number of users with conflicting payment + approval entitlements |
+| KRI 3 | % payment system access reviews overdue |
+| Amber threshold (KRI 1) | > 0.5% in any month |
+| Red threshold (KRI 1) | Any single payment > $1m released without dual approval |
+| Action on red | Within 24h: forensic review, suspension of single-approver capability, report to ORC |
+| Owner | Head of Payment Operations |
+
+This chain is what regulators (and a serious internal audit team) want to see.
+
+## Reporting Operational Risk KRIs
+
+A common reporting cadence:
+
+- **Daily** – cyber, fraud, payments / settlement breaks (1st-line ops dashboards).
+- **Weekly** – incidents, change failures, complaints (1st-line management).
+- **Monthly** – the Operational Risk Committee pack, with all amber/red KRIs and trends.
+- **Quarterly** – the Risk Committee of the Board.
+
+A good monthly KRI pack contains, at minimum: the trend chart, the threshold, the breach narrative, the root-cause analysis, the action with owner and due date, and a forward-looking commentary. Fifty pages of red dots without narrative is *worse* than no pack at all.
+
+## Common Pitfalls
+
+1. **Confusing volume metrics with risk metrics.** "Number of trades processed" is a KPI. "% trades failing settlement" is a KRI.
+2. **Too many KRIs.** Senior leadership can act on 25–35 KRIs in total. Anything beyond becomes shelfware.
+3. **Thresholds set to never trigger.** If nothing has been amber in 12 months, the threshold is wrong.
+4. **No backward-looking validation.** After every operational loss event, ask: "which KRI *should* have caught this, and did it?" If none did, design a new one.
+5. **Treating KRIs as static.** New products, new regulation, new threats demand new KRIs. Refresh the library at least annually.
+6. **Disconnected from capital and stress testing.** Under SMA, every operational loss feeds capital. KRIs should be linked into the same data spine that feeds the loss event database and ICAAP / ICAARA.
+
+## How Operational Risk KRIs Differ From Other Risk KRIs
+
+It is worth being explicit, since the lines blur in practice:
+
+- **Vs Credit Risk KRIs** – credit KRIs (PD, LGD, NPL ratio) describe the borrower; operational KRIs describe how *you* execute.
+- **Vs Market Risk KRIs** – market KRIs (VaR, sensitivities) describe price exposure; operational KRIs describe whether your trading, valuation, and back-office processes work.
+- **Vs Compliance KRIs** – compliance KRIs cover regulatory rule adherence; operational KRIs cover the broader execution machine. Conduct sits in both.
+- **Vs Cyber KRIs** – cyber KRIs are a *subset* of operational risk KRIs (Basel category 6 / 7), but most firms maintain a separate, deeper cyber dashboard.
+
+## A 90-Day Plan to Stand Up an Operational Risk KRI Programme
+
+- **Days 1–15:** Confirm the operational risk taxonomy and align with internal audit's universe.
+- **Days 15–30:** For the top 15 operational risks, brainstorm 3–5 candidate KRIs each. Score them against the five-test rubric.
+- **Days 30–45:** Identify data sources. Wire automated feeds where possible (incident system, HRIS, IAM, payment systems, vendor management, complaints, audit issues).
+- **Days 45–60:** Calculate provisional thresholds from history. Socialise with first-line owners.
+- **Days 60–75:** Define escalation playbooks. Assign accountable owners for every KRI.
+- **Days 75–90:** Run the first formal Operational Risk Committee with the new dashboard. Capture lessons. Iterate.
+
+By day 90, a mid-size firm should have 25–35 live operational risk KRIs feeding monthly governance.
+
+## Industry Variations: How the KRI Mix Shifts by Sector
+
+Operational risk taxonomy is universal, but the *mix* of KRIs that matter most varies sharply:
+
+- **Banking and Capital Markets:** Settlement fail rate, reconciliation breaks, conduct complaints, model performance drift, and trade-surveillance alert closure rates dominate. Basel SMA and PRA SS1/21 compliance are non-negotiable framings.
+- **Insurance:** Claims leakage, underwriting error rate, complaint upheld rate by ombudsman, and policy administration STP rate are tier-1 KRIs.
+- **Asset Management:** NAV error frequency, breach of investment guidelines, and trade-allocation exception rates sit at the top.
+- **Payments and Fintech:** Authorisation rate variance, chargeback rate, fraud loss per million in volume, and API uptime are the leading indicators investors and regulators watch.
+- **Healthcare:** Never-events, medication error rate, HIPAA breach reports, and credentialing lapses replace much of the conduct category.
+- **Energy and Utilities:** Process safety events (Tier 1 / Tier 2 per API RP 754), SAIDI/SAIFI for electric utilities, and environmental exceedances anchor the dashboard.
+- **Public Sector:** Service-delivery SLA breaches, FOIA / public-records response times, and procurement-fraud indicators take primacy.
+
+The taxonomy is universal; the calibration is local. Regulator expectations, customer contracts, and historical loss data should drive which KRIs sit at the top of your dashboard.
+
+## Tooling: What Actually Powers an Operational Risk KRI Programme
+
+Your KRI programme is only as good as its data plumbing. A pragmatic stack:
+
+- **Loss event database** – ORX, internal LED, or a GRC module – feeds historical calibration of thresholds.
+- **GRC platform** – Archer, ServiceNow IRM, LogicGate, MetricStream, Riskonnect, or Resolver – holds the risk register, control library, and KRI definitions in one place.
+- **Data layer** – a warehouse (Snowflake, Databricks, BigQuery, Synapse) that pulls from incident management, IAM, payments, complaints, HRIS, vendor management, and audit issue trackers.
+- **Visualisation** – Power BI or Tableau for the operating-level dashboards; the GRC tool for board-grade reports.
+- **Workflow** – SLA-tracked tickets for amber/red breaches, with auto-escalation to the named accountable owner.
+
+The single most common implementation failure is letting KRIs depend on monthly spreadsheet refreshes. Automate the feed, or expect the KRI to silently die within two quarters.
+
+## Worked Mini Case Study: Catching a Conduct Event Early
+
+A mid-size retail bank noticed three KRIs trending amber simultaneously over six weeks:
+
+1. **Sales-incentive risk score** – the proportion of variable comp tied to a single savings product had crept above its 85th-percentile threshold.
+2. **Complaints upheld rate** for that product had risen from 18% to 27%.
+3. **% sales reversed within the 14-day cooling-off window** had moved from 1.1% to 2.4%.
+
+No single KRI was a smoking gun. The combination was. A targeted thematic review found a regional sales team cross-selling the product to ineligible vulnerable customers. The bank acted within 30 days, refunded affected customers, and avoided a regulatory enforcement action that, based on comparable peers, would have cost roughly 20× the remediation programme.
+
+The lesson: operational risk events almost never light up a single red KRI in isolation. Watch correlated movements across categories.
+
+## Final Word
+
+Operational risk losses rarely arrive as a single catastrophe – they arrive as a *trend* that nobody was paid to watch. The regulators have given up waiting for firms to do this on their own. DORA, CPS 230, OCC heightened standards, and Basel SMA all now turn KRIs into a regulatory expectation, not a nice-to-have.
+
+The good news: the discipline pays for itself. Firms that run a tight KRI programme typically see 20–40% reductions in operational loss frequency over three years – not because risk falls, but because they catch events while they are still cheap to fix.
+
+Pick the five operational risk KRIs from this guide that map to your largest losses of the past three years. Wire them to live data. Set thresholds. Define what happens when red flashes. Do that, and you have already moved further than most enterprises ever will.


### PR DESCRIPTION
## Summary

Generates two blog posts from the editorial planning sheet, picking the two highest-priority entries that represent the two main content patterns:

- **Pattern A (Industry KRIs):** `blog/key-risk-indicators-examples-for-manufacturing-companies.md` — ~2,700 words, target keyword *key risk indicators examples for manufacturing*. Covers Safety, Operational/Equipment, Quality, Supply Chain, EHS, Cyber/OT, Workforce, Financial, and Regulatory KRIs with formulas, thresholds, sub-sector tailoring (automotive, aerospace, F&B, pharma, chemicals, heavy industry), tooling, and a 90-day rollout plan.
- **Pattern B (Risk-Type Pillar):** `blog/operational-risk-key-risk-indicators-examples.md` — ~2,900 words, target keyword *operational risk key risk indicators*. Basel-aligned across all 10 Level-1 event types, with quantitative vs qualitative KRIs, threshold methodology, regulatory context (Basel SMA, DORA, CPS 230, OCC, FCA), industry variations, a worked conduct case study, and a 90-day implementation plan.

Both posts follow the structure of the top-performing reference posts called out in the sheet (KRI Examples for Banks; Fraud KRI Examples).

## Test plan

- [ ] Editorial review for tone, accuracy, and brand voice
- [ ] SEO check: target keyword density, meta description length, headings (H2/H3) hierarchy
- [ ] Verify regulatory citations (Basel, OSHA, ISO 45001, IATF 16949, DORA, CPS 230) are current
- [ ] Convert frontmatter and tables to the CMS format used on the live site before publishing
- [ ] Add internal links to existing related posts (Fraud KRI Examples, KRI Examples for Banks, KRIs for HR, NIST cyber KRI post)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sTNqVE7GAtTC2ujyXn6Ne)_